### PR TITLE
Add start and end options as well as days back for harvesting

### DIFF
--- a/share/management/commands/harvest.py
+++ b/share/management/commands/harvest.py
@@ -1,3 +1,4 @@
+import arrow
 import datetime
 
 from django.apps import apps
@@ -15,15 +16,26 @@ class Command(BaseCommand):
         parser.add_argument('--all', action='store_true', help='Run all harvester')
         parser.add_argument('harvester', nargs='*', type=str, help='The name of the harvester to run')
         parser.add_argument('--async', action='store_true', help='Whether or not to use Celery')
-        parser.add_argument('--days-back', type=int, help='The number of days to go back')
+
+        parser.add_argument('--days-back', type=int, help='The number of days to go back, defaults to 1')
+        parser.add_argument('--start', type=str, help='The day to start harvesting, in the format YYYY-MM-DD')
+        parser.add_argument('--end', type=str, help='The day to end harvesting, in the format YYYY-MM-DD')
 
     def handle(self, *args, **options):
         user = ShareUser.objects.get(username=settings.APPLICATION_USERNAME)
 
         task_kwargs = {}
+
+        if options['days_back'] and (options['start'] or options['end']):
+            self.stdout.write('Please choose days-back OR a start date with end date, not both')
+            return
+
         if options['days_back']:
             task_kwargs['end'] = (datetime.datetime.utcnow() + datetime.timedelta(days=-(options['days_back'] - 1))).isoformat() + 'Z'
             task_kwargs['start'] = (datetime.datetime.utcnow() + datetime.timedelta(days=-options['days_back'])).isoformat() + 'Z'
+        else:
+            task_kwargs['start'] = arrow.get(options['start']) if options.get('start') else arrow.utcnow() - datetime.timedelta(days=int(options.get('days_back', 1)))
+            task_kwargs['end'] = arrow.get(options['end']) if options.get('end') else arrow.utcnow()
 
         if not options['harvester'] and options['all']:
             options['harvester'] = [x.label for x in apps.get_app_configs() if isinstance(x, ProviderAppConfig)]


### PR DESCRIPTION
For local testing harvesters that may not have content in a one day period, allow the option to pass in a date for start and end. 

```python manage.py harvest edu.mit --start 2016-07-01```
```python manage.py harvest edu.mit --start 2016-05-01 --end 2016-06-01```