### PR TITLE
Also exclude robots with no long title as these are processing bots

### DIFF
--- a/api/views/workflow.py
+++ b/api/views/workflow.py
@@ -24,7 +24,7 @@ class ProviderViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProviderSerializer
 
     def get_queryset(self):
-        return ShareUser.objects.exclude(robot='')
+        return ShareUser.objects.exclude(robot='').exclude(long_title='')
 
 
 class NormalizedDataViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
The provider API endpoint should just show providers, but elasticsearch and automerge bots are in there too. Also filter for bots that don't have a name as those are not Provider bot users!