### PR TITLE
Link back to docs in API header

### DIFF
--- a/templates/rest_framework/api.html
+++ b/templates/rest_framework/api.html
@@ -14,6 +14,10 @@
         <link rel="stylesheet" type="text/css" href="{% static "css/api_custom.css" %}"/>
     {% endblock %}
 
+      {% block userlinks %}
+        <li><a href="http://share-research.readthedocs.io/">Documentation</a></li>
+      {% endblock %}
+
     {% block branding %}
         <img class="logo" src="{% static 'img/share.png' %}"/>
         <!--<img class="logo" src="project/static/img/share.png"/>-->


### PR DESCRIPTION
Add link in API header that goes to http://share-research.readthedocs.io/

![screen shot 2016-07-10 at 7 34 06 pm](https://cloud.githubusercontent.com/assets/801594/16716820/5a7d5a10-46d5-11e6-9490-4f515a2ce49b.png)
