### PR TITLE
CrossRef Fixes and Additions

### DIFF
--- a/providers/org/crossref/harvester.py
+++ b/providers/org/crossref/harvester.py
@@ -11,7 +11,7 @@ class CrossRefHarvester(Harvester):
         end_date = end_date.date()
 
         return self.fetch_records(furl(self.url).set(query_params={
-            'filter': 'from-pub-date:{},until-pub-date:{}'.format(
+            'filter': 'from-update-date:{},until-update-date:{}'.format(
                 start_date.isoformat(),
                 end_date.isoformat()
             ),
@@ -29,7 +29,7 @@ class CrossRefHarvester(Harvester):
 
         # make requests for the remaining records
         for i in range(1000, total, 1000):
-            response = self.requests.get(furl(self.url).add(query_params={
+            response = self.requests.get(furl(url).add(query_params={
                 'offset': i
             }).url)
 

--- a/providers/org/crossref/normalizer.py
+++ b/providers/org/crossref/normalizer.py
@@ -34,16 +34,32 @@ class Affiliation(Parser):
     pass
 
 
+class Identifier(Parser):
+    base_url = 'https://orcid.org'
+    url = ctx
+
+
+class ThroughIdentifiers(Parser):
+    identifier = Delegate(Identifier, ctx)
+
+
 class Person(Parser):
     given_name = Maybe(ctx, 'given')
     family_name = Maybe(ctx, 'family')
     affiliations = Map(Delegate(Affiliation.using(entity=Delegate(Organization))), Maybe(ctx, 'affiliation'))
+    identifiers = Map(Delegate(ThroughIdentifiers), Maybe(ctx, 'ORCID'))
 
 
 class Contributor(Parser):
     person = Delegate(Person, ctx)
     order_cited = ctx('index')
-    cited_name = links.Join(Concat(ctx.given, ctx.family), ' ')
+    cited_name = links.Join(
+        Concat(
+            Maybe(ctx, 'given'),
+            Maybe(ctx, 'family')
+        ),
+        joiner=' '
+    )
 
 
 class CreativeWork(Parser):


### PR DESCRIPTION
h/t to @kjw for improving CrossRef's metadata docs so the normalizer could easily be improved 🎉 
- Normalize additional data in the ```Extra``` class.
- Normalize contributor ORCIDs as ```Identifiers```
- Fix ```cited_name``` by making 'given' a ```Maybe```
- Normalize funder and award information.

Closes #259 