### PR TITLE
Rename oauth scope to match OSF

### DIFF
--- a/osf_oauth2_adapter/apps.py
+++ b/osf_oauth2_adapter/apps.py
@@ -8,5 +8,5 @@ class OsfOauth2AdapterConfig(AppConfig):
     # staging by default so people don't have to run OSF to use this.
     osf_api_url = os.environ.get('OSF_API_URL', 'https://staging-api.osf.io').rstrip('/') + '/'
     osf_accounts_url = os.environ.get('OSF_ACCOUNTS_URL', 'https://staging-accounts.osf.io').rstrip('/') + '/'
-    default_scopes = ['osf.users.all_read',]
+    default_scopes = ['osf.users.profile_read',]
     humans_group_name = 'OSF_USERS'

--- a/project/settings.py
+++ b/project/settings.py
@@ -217,7 +217,7 @@ SOCIALACCOUNT_PROVIDERS = \
     {'osf':
          {
             'METHOD': 'oauth2',
-            'SCOPE': ['osf.users.all_read'],
+            'SCOPE': ['osf.users.profile_read'],
             'AUTH_PARAMS': {'access_type': 'offline'},
           # 'FIELDS': [
           #     'id',


### PR DESCRIPTION
Use `osf.users.profile_read` instead of `osf.users.all_read`, following CenterForOpenScience/osf.io@84dacefc77768a6f20220cd87984c8557e4b493d 