### PR TITLE
ES mapping changes (don't merge until we can reindex)

### DIFF
--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -59,7 +59,7 @@ class CreativeWorksRSS(Feed):
 
         def get_item(hit):
             source = hit.get('_source')
-            source['@id'] = hit.get('_id')
+            source['id'] = hit.get('_id')
             return source
 
         return [get_item(hit) for hit in json_response['hits']['hits']]
@@ -72,7 +72,7 @@ class CreativeWorksRSS(Feed):
 
     def item_link(self, item):
         # Link to SHARE curate page
-        return '{}{}/curate/{}/{}'.format(settings.SHARE_API_URL, settings.EMBER_SHARE_PREFIX, item.get('@type'), item.get('@id'))
+        return '{}{}/curate/{}/{}'.format(settings.SHARE_API_URL, settings.EMBER_SHARE_PREFIX, item.get('type'), item.get('id'))
 
     def item_pubdate(self, item):
         pubdate = item.get('date')
@@ -84,7 +84,7 @@ class CreativeWorksRSS(Feed):
 
     def item_categories(self, item):
         categories = [item.get('subject')]
-        categories.extend(item.get('tags'))
+        categories.extend(item.get('tag'))
         return [sanitize_for_xml(c) for c in categories if c]
 
 class CreativeWorksAtom(CreativeWorksRSS):

--- a/bots/elasticsearch/bot.py
+++ b/bots/elasticsearch/bot.py
@@ -48,13 +48,7 @@ class ElasticSearchBot(Bot):
                         }
                     }
                 }
-            }],
-            'properties': {
-                'sources': {
-                    'type': 'string',
-                    'index': 'not_analyzed'
-                }
-            }
+            }]
         },
         'entity': {
             'properties': {
@@ -63,10 +57,6 @@ class ElasticSearchBot(Bot):
         },
         'person': {
             'properties': {
-                'sources': {
-                    'type': 'string',
-                    'index': 'not_analyzed'
-                },
                 'suggest': SUGGEST_MAPPING
             }
         },

--- a/bots/elasticsearch/bot.py
+++ b/bots/elasticsearch/bot.py
@@ -48,7 +48,12 @@ class ElasticSearchBot(Bot):
                         }
                     }
                 }
-            }]
+            }],
+            'properties': {
+                'lists': {
+                    'enabled': False
+                }
+            }
         },
         'entity': {
             'properties': {

--- a/bots/elasticsearch/bot.py
+++ b/bots/elasticsearch/bot.py
@@ -28,9 +28,9 @@ class ElasticSearchBot(Bot):
         'type': 'completion',
         'payloads': True,
         'context': {
-            '@type': {
+            'type': {
                 'type': 'category',
-                'path': '@type'
+                'path': 'type'
             }
         }
     }

--- a/bots/elasticsearch/tasks.py
+++ b/bots/elasticsearch/tasks.py
@@ -22,7 +22,7 @@ def safe_substr(value, length=32000):
     return None
 
 
-def add_suggest(obj):
+def add_suggest(obj, weight=None):
     if obj['name']:
         obj['suggest'] = {
             'input': re.split('[\\s,]', obj['name']) + [obj['name']],
@@ -31,7 +31,8 @@ def add_suggest(obj):
                 '@id': obj['@id'],
                 'name': obj['name'],
                 '@type': obj['@type'],
-            }
+            },
+            'weight': weight
         }
     return obj
 
@@ -78,7 +79,7 @@ class IndexModelTask(ProviderTask):
                 for affiliation in
                 person.affiliations.all()
             ],
-            'sources': [source.robot for source in person.sources.all()],
+            'sources': [self.serialize_source(source) for source in person.sources.all()],
         }
         return add_suggest(serialized_person) if suggest else serialized_person
 
@@ -128,8 +129,6 @@ class IndexModelTask(ProviderTask):
 
     def serialize_source(self, source):
         return {
-            '@id': str(source.pk),
-            '@type': 'source',
             'name': safe_substr(source.long_title),
             'short_name': safe_substr(source.robot)
         }

--- a/bots/elasticsearch/tasks.py
+++ b/bots/elasticsearch/tasks.py
@@ -124,7 +124,7 @@ class IndexModelTask(ProviderTask):
             'awards': [safe_substr(award) for award in creative_work.awards.all()],
             'venues': [safe_substr(venue) for venue in creative_work.venues.all()],
             'sources': [self.serialize_source(source) for source in creative_work.sources.all()],
-            'contributors': [self.serialize_person(person, False) for person in creative_work.contributors.all()],
+            'contributors': [self.serialize_person(person, False) for person in creative_work.contributors.order_by('contributor__order_cited')],
         }
 
     def serialize_source(self, source):

--- a/bots/elasticsearch/tasks.py
+++ b/bots/elasticsearch/tasks.py
@@ -29,7 +29,7 @@ def score_text(text):
     )
 
 
-def add_suggest(obj, weight=None):
+def add_suggest(obj):
     if obj['name']:
         obj['suggest'] = {
             'input': re.split('[\\s,]', obj['name']) + [obj['name']],
@@ -39,9 +39,8 @@ def add_suggest(obj, weight=None):
                 'name': obj['name'],
                 '@type': obj['@type'],
             },
+            'weight': score_text(obj['name'])
         }
-        if weight is not None:
-            obj['suggest']['weight'] = weight
     return obj
 
 
@@ -107,7 +106,7 @@ class IndexModelTask(ProviderTask):
             '@type': 'tag',
             'name': safe_substr(tag.name),
         }
-        return add_suggest(serialized_tag, weight=score_text(tag.name)) if suggest else serialized_tag
+        return add_suggest(serialized_tag) if suggest else serialized_tag
 
     def serialize_creative_work(self, creative_work):
         serialized_lists = {

--- a/bots/elasticsearch/tasks.py
+++ b/bots/elasticsearch/tasks.py
@@ -35,9 +35,9 @@ def add_suggest(obj):
             'input': re.split('[\\s,]', obj['name']) + [obj['name']],
             'output': obj['name'],
             'payload': {
-                '@id': obj['@id'],
+                'id': obj['id'],
                 'name': obj['name'],
-                '@type': obj['@type'],
+                'type': obj['type'],
             },
             'weight': score_text(obj['name'])
         }
@@ -70,8 +70,8 @@ class IndexModelTask(ProviderTask):
 
     def serialize_person(self, person, suggest=True):
         serialized_person = {
-            '@id': person.pk,
-            '@type': 'person',
+            'id': person.pk,
+            'type': 'person',
             'suffix': safe_substr(person.suffix),
             'given_name': safe_substr(person.given_name),
             'family_name': safe_substr(person.family_name),
@@ -92,8 +92,8 @@ class IndexModelTask(ProviderTask):
 
     def serialize_entity(self, entity, suggest=True):
         serialized_entity = {
-            '@id': entity.pk,
-            '@type': type(entity).__name__.lower(),
+            'id': entity.pk,
+            'type': type(entity).__name__.lower(),
             'name': safe_substr(entity.name),
             'url': entity.url,
             'location': safe_substr(entity.location),
@@ -102,8 +102,8 @@ class IndexModelTask(ProviderTask):
 
     def serialize_tag(self, tag, suggest=True):
         serialized_tag = {
-            '@id': str(tag.pk),
-            '@type': 'tag',
+            'id': str(tag.pk),
+            'type': 'tag',
             'name': safe_substr(tag.name),
         }
         return add_suggest(serialized_tag) if suggest else serialized_tag
@@ -118,7 +118,7 @@ class IndexModelTask(ProviderTask):
         }
 
         return {
-            '@type': type(creative_work).__name__.lower(),
+            'type': type(creative_work).__name__.lower(),
             'title': safe_substr(creative_work.title),
             'description': safe_substr(creative_work.description),
             'language': safe_substr(creative_work.language),
@@ -163,8 +163,8 @@ class IndexSourceTask(ProviderTask):
 
     def serialize(self, source):
         serialized_source = {
-            '@id': str(source.pk),
-            '@type': 'source',
+            'id': str(source.pk),
+            'type': 'source',
             'name': safe_substr(source.long_title),
             'short_name': safe_substr(source.robot)
         }

--- a/bots/elasticsearch/tasks.py
+++ b/bots/elasticsearch/tasks.py
@@ -122,8 +122,16 @@ class IndexModelTask(ProviderTask):
             'links': [safe_substr(link) for link in creative_work.links.all()],
             'awards': [safe_substr(award) for award in creative_work.awards.all()],
             'venues': [safe_substr(venue) for venue in creative_work.venues.all()],
-            'sources': [safe_substr(source.long_title) for source in creative_work.sources.all()],
+            'sources': [self.serialize_source(source) for source in creative_work.sources.all()],
             'contributors': [self.serialize_person(person, False) for person in creative_work.contributors.all()],
+        }
+
+    def serialize_source(self, source):
+        return {
+            '@id': str(source.pk),
+            '@type': 'source',
+            'name': safe_substr(source.long_title),
+            'short_name': safe_substr(source.robot)
         }
 
 


### PR DESCRIPTION
### Merging will break staging until the elastic index is rebuilt!

* Sort contributors by `order_cited` (fixes #343)
* Sort suggestions based on how useful they seem (shorter, more alphabety strings are better) (fixes #342)
* More human-friendly field names for easier query composition (helps resolve #340, #345)
 * allows queries like `contributor:einstein AND title:giraffes`
 * available fields: `title`, `description`, `source`, `tag`, `language`, `date`, `award`, `venue`, `contributor`, `funder`, `publisher`, `institution`, `organization`

For local dev installs, rebuild the elastic index after pulling:
```
curl -XDELETE 'http://localhost:9200/share'
./manage.py runbot elasticsearch --last-run=0
```