### PR TITLE
Change DatetimeAwareJSONField to properly encode/decode things

### DIFF
--- a/share/models/base.py
+++ b/share/models/base.py
@@ -141,7 +141,7 @@ class VersionManager(FuzzyCountManager):
 
 
 class ExtraData(models.Model, metaclass=ShareObjectMeta):
-    data = fields.DatetimeAwareJSONField(default=dict)
+    data = fields.DateTimeAwareJSONField(default=dict)
 
     objects = FuzzyCountManager()
     versions = VersionManager()

--- a/share/models/core.py
+++ b/share/models/core.py
@@ -17,7 +17,7 @@ from fuzzycount import FuzzyCountManager
 from oauth2_provider.models import AccessToken, Application
 
 from osf_oauth2_adapter.apps import OsfOauth2AdapterConfig
-from share.models.fields import DatetimeAwareJSONField, ShareURLField
+from share.models.fields import DateTimeAwareJSONField, ShareURLField
 from share.models.validators import JSONLDValidator
 
 logger = logging.getLogger(__name__)
@@ -218,7 +218,7 @@ class NormalizedData(models.Model):
     created_at = models.DateTimeField(null=True)
     raw = models.ForeignKey(RawData, null=True)
     # TODO Rename this to data
-    normalized_data = DatetimeAwareJSONField(default={}, validators=[JSONLDValidator(), ])
+    normalized_data = DateTimeAwareJSONField(default={}, validators=[JSONLDValidator(), ])
     source = models.ForeignKey(settings.AUTH_USER_MODEL)
     tasks = models.ManyToManyField('CeleryProviderTask')
 

--- a/share/models/fields.py
+++ b/share/models/fields.py
@@ -36,7 +36,7 @@ def decode_datetime_objects(nested_value):
     if isinstance(nested_value, list):
         return [decode_datetime_objects(item) for item in nested_value]
     elif isinstance(nested_value, dict):
-        for key, value in nested_value.iteritems():
+        for key, value in nested_value.items():
             if isinstance(value, dict) and 'type' in value.keys():
                 if value['type'] == 'encoded_datetime':
                     nested_value[key] = parser.parse(value['value'])

--- a/share/models/fields.py
+++ b/share/models/fields.py
@@ -1,40 +1,89 @@
-import six
-import ujson
+import datetime as dt
+import json
+from decimal import Decimal
+from functools import partial
 
+import six
+from dateutil import parser
 from django import forms
-from psycopg2.extras import Json
 from django.contrib.postgres import lookups
 from django.contrib.postgres.fields.jsonb import JSONField
 from django.core import exceptions, validators, checks
+from django.core.exceptions import ValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models.fields.related import resolve_relation
 from django.utils.translation import ugettext_lazy as _
+from psycopg2.extras import Json
+
 from share.models.validators import is_valid_uri
 
 
-class DatetimeAwareJSONField(JSONField):
+class DateTimeAwareJSONEncoder(DjangoJSONEncoder):
+    def default(self, o):
+        if isinstance(o, dt.datetime):
+            return dict(type='encoded_datetime', value=o.isoformat())
+        elif isinstance(o, dt.date):
+            return dict(type='encoded_date', value=o.isoformat())
+        elif isinstance(o, dt.time):
+            return dict(type='encoded_time', value=o.isoformat())
+        elif isinstance(o, Decimal):
+            return dict(type='encoded_decimal', value=str(o))
+        return super(DateTimeAwareJSONEncoder, self).default(o)
+
+
+def decode_datetime_objects(nested_value):
+    if isinstance(nested_value, list):
+        return [decode_datetime_objects(item) for item in nested_value]
+    elif isinstance(nested_value, dict):
+        for key, value in nested_value.iteritems():
+            if isinstance(value, dict) and 'type' in value.keys():
+                if value['type'] == 'encoded_datetime':
+                    nested_value[key] = parser.parse(value['value'])
+                if value['type'] == 'encoded_date':
+                    nested_value[key] = parser.parse(value['value']).date()
+                if value['type'] == 'encoded_time':
+                    nested_value[key] = parser.parse(value['value']).time()
+                if value['type'] == 'encoded_decimal':
+                    nested_value[key] = Decimal(value['value'])
+            elif isinstance(value, dict):
+                nested_value[key] = decode_datetime_objects(value)
+            elif isinstance(value, list):
+                nested_value[key] = decode_datetime_objects(value)
+        return nested_value
+    return nested_value
+
+
+class DateTimeAwareJSONField(JSONField):
     def get_prep_value(self, value):
         if value is not None:
-            return Json(value, dumps=ujson.dumps)
+            return Json(value, dumps=partial(json.dumps, cls=DateTimeAwareJSONEncoder))
         return value
+
+    def to_python(self, value):
+        if value is None:
+            return None
+        return super(DateTimeAwareJSONField, self).to_python(decode_datetime_objects(value))
 
     def get_prep_lookup(self, lookup_type, value):
         if lookup_type in ('has_key', 'has_keys', 'has_any_keys'):
             return value
         if isinstance(value, (dict, list)):
-            return Json(value, dumps=ujson.dumps)
+            return Json(value, dumps=partial(json.dumps, cls=DateTimeAwareJSONEncoder))
         return super(JSONField, self).get_prep_lookup(lookup_type, value)
 
     def validate(self, value, model_instance):
         super(JSONField, self).validate(value, model_instance)
         try:
-            ujson.dumps(value)
+            json.dumps(value, cls=DateTimeAwareJSONEncoder)
         except TypeError:
-            raise exceptions.ValidationError(
+            raise ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
                 params={'value': value},
             )
+
+DatetimeAwareJSONField = DateTimeAwareJSONField
 
 
 JSONField.register_lookup(lookups.DataContains)

--- a/tests/share/models/test_datetimeawarejsonfield.py
+++ b/tests/share/models/test_datetimeawarejsonfield.py
@@ -1,0 +1,68 @@
+import datetime as dt
+import json
+from decimal import Decimal
+
+from django.test import TestCase
+from share.models.fields import DateTimeAwareJSONEncoder, decode_datetime_objects
+
+
+class DateTimeAwareJSONFieldTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.json_dict_data = dict(
+            sample_date=dt.date.today(),
+            nested_data=dict(
+                sample_date=dt.date.today(),
+                sample_datetime=dt.datetime.utcnow(),
+                sample_decimal=Decimal("10.259")
+            ),
+            sample_datetime=dt.datetime.utcnow(),
+            sample_decimal=Decimal("10.259"),
+            sample_text='wut wut',
+            list_of_things=[
+                dict(
+                    sample_date=dt.date.today(),
+                    sample_datetime=dt.datetime.utcnow(),
+                    sample_decimal=Decimal("10.259")
+                ),
+                dict(
+                    sample_date=dt.date.today(),
+                    sample_datetime=dt.datetime.utcnow(),
+                    sample_decimal=Decimal("10.259")
+                ),
+                [
+                    dict(
+                        sample_date=dt.date.today(),
+                        sample_datetime=dt.datetime.utcnow(),
+                        sample_decimal=Decimal("10.259")
+                    ),
+                    dict(
+                        sample_date=dt.date.today(),
+                        sample_datetime=dt.datetime.utcnow(),
+                        sample_decimal=Decimal("10.259")
+                    ),
+                ]
+            ]
+        )
+        cls.json_list_data = [
+            dict(
+                sample_date=dt.date.today(),
+                sample_datetime=dt.datetime.utcnow(),
+                sample_decimal=Decimal("10.259")
+            ),
+            dict(
+                sample_date=dt.date.today(),
+                sample_datetime=dt.datetime.utcnow(),
+                sample_decimal=Decimal("10.259")
+            ),
+        ]
+
+    def test_dict(self):
+        json_string = json.dumps(self.json_dict_data, cls=DateTimeAwareJSONEncoder)
+        json_data = decode_datetime_objects(json.loads(json_string))
+        assert json_data == self.json_dict_data, 'Nope'
+
+    def test_list(self):
+        json_string = json.dumps(self.json_list_data, cls=DateTimeAwareJSONEncoder)
+        json_data = decode_datetime_objects(json.loads(json_string))
+        assert json_data == self.json_list_data, 'Nope'


### PR DESCRIPTION
@icereval @chrisseto This upgrades the JSONField to be compatible with datetime, date, time, and Decimal. It's fairly obvious how to add other formats. Line 22 and Line 35 show encoding and decoding, respectively. This is NOT compatible with the current format and since we're wiping the DB (and it would be very nearly impossible) I didn't write a migration. Datetimes are currently stored as epoch so.... Finding them and re-encoding them to this new format would be hard.