### PR TITLE
Add travis file to run python tests and flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Config file for automatic testing at travis-ci.org
+
+language: python
+
+python:
+    - "3.5"
+
+sudo: false
+
+cache:
+    directories:
+      - node_modules
+
+install:
+    - travis_retry pip install --upgrade pip
+    - travis_retry pip install flake8==2.4.0 --force-reinstall --upgrade
+    - travis_retry pip install -r dev-requirements.txt
+
+# Run Python tests and flake8
+script:
+    - flake8 .
+    - py.test tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+# E501: Line too long
+# F403: * imports
 [flake8]
 max-line-length = 250
-ignore = W503
+ignore = E501,W503,F403
+exclude = */migrations/*


### PR DESCRIPTION
Related to #371 

Note: I don't have admin access on this repository so the travis build needs to be enabled