### PR TITLE
RawData for a given ShareObject

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -21,7 +21,7 @@ class ChangeSerializer(serializers.ModelSerializer):
     self = serializers.HyperlinkedIdentityField(view_name='api:change-detail')
     class Meta:
         model = models.Change
-        fields = ('self', 'id', 'change', 'node_id', 'type', 'target', 'target_version')
+        fields = ('self', 'id', 'change', 'node_id', 'type', 'target_version', 'target_type', 'target_id')
 
 
 class ShareUserSerializer(serializers.ModelSerializer):

--- a/api/views/workflow.py
+++ b/api/views/workflow.py
@@ -148,6 +148,23 @@ class ChangeViewSet(viewsets.ModelViewSet):
 
 
 class RawDataViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Raw data, exactly as harvested from the data source.
+
+    ## Query by object
+    To get all the raw data corresponding to a Share object, use the query
+    parameters `object_id=<@id>` and `object_type=<@type>`
+    """
+
     serializer_class = RawDataSerializer
 
-    queryset = RawData.objects.all()
+    def get_queryset(self):
+        object_id = self.request.query_params.get('object_id', None)
+        object_type = self.request.query_params.get('object_type', None)
+        if object_id and object_type:
+            return RawData.objects.filter(
+                normalizeddata__changeset__changes__target_id=object_id,
+                normalizeddata__changeset__changes__target_type__model=object_type
+            ).distinct('id')
+        else:
+            return RawData.objects.all()

--- a/share/models/change.py
+++ b/share/models/change.py
@@ -167,6 +167,8 @@ class Change(models.Model):
             try:
                 with transaction.atomic():
                     inst.save()
+                    self.target_id = inst.id
+                    self.save()
             except IntegrityError as e:
                 from share.disambiguation import disambiguate
                 logger.info('Handling unique violation error %r', e)


### PR DESCRIPTION
Add query params `object_id` and `object_type` to the `/api/rawdata` endpoint. When both are given, returns all `RawData` objects associated with the specified object.

Also, set `change.target_id` when a new object is created from an accepted `Change`.