### PR TITLE
Only label RePEc's preprints as preprints

### DIFF
--- a/providers/org/repec/apps.py
+++ b/providers/org/repec/apps.py
@@ -9,4 +9,3 @@ class AppConfig(OAIProviderAppConfig):
     home_page = 'http://repec.org/'
     url = 'http://oai.repec.org'
     time_granularity = False
-    emitted_type = 'preprint'

--- a/share/normalize/oai.py
+++ b/share/normalize/oai.py
@@ -116,7 +116,7 @@ class OAICreativeWork(Parser):
             if resourceType == 'preprint':
                 return 'Preprint'
             return 'CreativeWork'
-        except KeyError:
+        except (KeyError, ValueError):
             return 'CreativeWork'
 
     ORGANIZATION_KEYWORDS = (

--- a/share/normalize/oai.py
+++ b/share/normalize/oai.py
@@ -109,7 +109,15 @@ class OAIThroughTags(Parser):
 
 
 class OAICreativeWork(Parser):
-    schema = 'CreativeWork'
+    @property
+    def schema(self):
+        try:
+            resourceType = self.context['record']['metadata']['dc']['dc:type']
+            if resourceType == 'preprint':
+                return 'Preprint'
+            return 'CreativeWork'
+        except KeyError:
+            return 'CreativeWork'
 
     ORGANIZATION_KEYWORDS = (
         'the',


### PR DESCRIPTION
Resolves #417 

* this also impacts any OAI creativework that has "preprint" as the type