### PR TITLE
[hotfix] Handle clinical trials better.

### DIFF
--- a/providers/gov/clinicaltrials/normalizer.py
+++ b/providers/gov/clinicaltrials/normalizer.py
@@ -48,7 +48,10 @@ class Contributor(Parser):
 
 
 class CreativeWork(Parser):
-    title = Maybe(ctx.clinical_study, 'official_title')
+    title = OneOf(
+        ctx.clinical_study.official_title,
+        ctx.clinical_study.brief_title
+    )
     description = Maybe(ctx.clinical_study, 'brief_summary')['textblock']
     contributors = Map(
         Delegate(Contributor),

--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -158,6 +158,6 @@ class AbstractCreativeWorkDisambiguator(Disambiguator):
 
         filter = {k: v for k, v in self.attrs.items() if not isinstance(v, list)}
         if filter:
-            # Limitting the length of title forces postgres to use the partial index
+            # Limiting the length of title forces postgres to use the partial index
             return self.model.objects.filter(**filter).extra(where=('octet_length(title) < 2049', )).first()
         return None

--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -151,10 +151,10 @@ class AbstractCreativeWorkDisambiguator(Disambiguator):
                 if len(models) == 1 and 'issn' not in models[0].link.type.lower():
                     return models[0].creative_work
 
-        if not self.attrs.get('title') or len(self.attrs['title']) > 2048:
-            return None
-
         self.attrs.pop('description', None)
+
+        if not self.attrs or not self.attrs.get('title') or len(self.attrs['title']) > 2048:
+            return None
 
         # Limitting the length of title forces postgres to use the partial index
         return self.model.objects.filter(**{k: v for k, v in self.attrs.items() if not isinstance(v, list)}).extra(where=('octet_length(title) < 2049', )).first()

--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -151,10 +151,13 @@ class AbstractCreativeWorkDisambiguator(Disambiguator):
                 if len(models) == 1 and 'issn' not in models[0].link.type.lower():
                     return models[0].creative_work
 
-        self.attrs.pop('description', None)
-
-        if not self.attrs or not self.attrs.get('title') or len(self.attrs['title']) > 2048:
+        if not self.attrs.get('title') or len(self.attrs['title']) > 2048:
             return None
 
-        # Limitting the length of title forces postgres to use the partial index
-        return self.model.objects.filter(**{k: v for k, v in self.attrs.items() if not isinstance(v, list)}).extra(where=('octet_length(title) < 2049', )).first()
+        self.attrs.pop('description', None)
+
+        filter = {k: v for k, v in self.attrs.items() if not isinstance(v, list)}
+        if filter:
+            # Limitting the length of title forces postgres to use the partial index
+            return self.model.objects.filter(**filter).extra(where=('octet_length(title) < 2049', )).first()
+        return None

--- a/share/models/change.py
+++ b/share/models/change.py
@@ -178,7 +178,7 @@ class Change(models.Model):
                 logger.info('Handling unique violation error %r', e)
 
                 self.type = Change.TYPE.update
-                self.target = disambiguate('_:', {k: v['@id'] if isinstance(v, dict) else v for k, v in resolved_change.items()}, self.target_type.model_class())
+                self.target = disambiguate('_:', resolved_change, self.target_type.model_class())
 
                 logger.info('Updating target to %r and type to update', self.target)
                 self.save()

--- a/share/models/change.py
+++ b/share/models/change.py
@@ -165,7 +165,8 @@ class Change(models.Model):
         return self._merge(save=save)
 
     def _create(self, save=True):
-        inst = self.target_type.model_class()(change=self, **self._resolve_change())
+        resolved_change = self._resolve_change()
+        inst = self.target_type.model_class()(change=self, **resolved_change)
         if save:
             try:
                 with transaction.atomic():
@@ -177,7 +178,7 @@ class Change(models.Model):
                 logger.info('Handling unique violation error %r', e)
 
                 self.type = Change.TYPE.update
-                self.target = disambiguate('_:', {k: v['@id'] if isinstance(v, dict) else v for k, v in self.change.items()}, self.target_type.model_class())
+                self.target = disambiguate('_:', {k: v['@id'] if isinstance(v, dict) else v for k, v in resolved_change.items()}, self.target_type.model_class())
 
                 logger.info('Updating target to %r and type to update', self.target)
                 self.save()


### PR DESCRIPTION
- Make sure we always have a title for gov.clinicaltrials documents
- Turns out `model.objects.filter(**{})` returns everything, don't disambiguate like that (this is probably why work `1` is so messed up)
- Don't try to resolve insert conflicts using `'_:xyz'` ids (caused problems on clinical trials with hundreds of venues)