### PR TITLE
[SHARE-428][Feature][2.0.0] Normalize white space when parsing

### DIFF
--- a/share/normalize/parsers.py
+++ b/share/normalize/parsers.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from functools import reduce
 
@@ -98,7 +99,7 @@ class Parser(metaclass=ParserMeta):
 
             if value is not None:
                 self.validate(field, value)
-                inst[key] = value
+                inst[key] = self._normalize_white_space(value)
 
         inst['extra'] = {}
         for key, chain in self._extra.items():
@@ -115,3 +116,8 @@ class Parser(metaclass=ParserMeta):
 
         # Return only a reference to the parsed object to avoid circular data structures
         return self.ref
+
+    def _normalize_white_space(self, value):
+        if not isinstance(value, str):
+            return value
+        return re.sub(r'\s+', ' ', value.strip())

--- a/tests/share/normalize/test_json.py
+++ b/tests/share/normalize/test_json.py
@@ -53,4 +53,9 @@ class TestParser:
 
     def test_parser(self):
         parsed = Article(EXAMPLE).parse()
-        assert ctx.pool[parsed]['extra'] == {'type': 'paper', 'defined_type': 'paper'}
+        normalized = ctx.pool[parsed]
+        assert normalized['extra'] == {'type': 'paper', 'defined_type': 'paper'}
+
+        # no newlines, leading/trailing white space, or multiple spaces
+        assert normalized['title'] == 'Photochemical Carbon Dioxide Reduction on Mg-Doped Ga(In)N Nanowire Arrays under Visible Light Irradiation'
+        assert normalized['description'] == 'The photochemical reduction of carbon dioxide (CO<sub>2</sub>) into energy-rich products can potentially address some of the critical challenges we face today, including energy resource shortages and greenhouse gas emissions. Our ab initio calculations show that CO<sub>2</sub> molecules can be spontaneously activated on the clean nonpolar surfaces of wurtzite metal nitrides, for example, Ga\u00ad(In)\u00adN. We have further demonstrated the photoreduction of CO<sub>2</sub> into methanol (CH<sub>3</sub>OH) with sunlight as the only energy input. A conversion rate of CO<sub>2</sub> into CH<sub>3</sub>OH (\u223c0.5 mmol g<sub>cat</sub><sup>\u20131</sup> h<sup>\u20131</sup>) is achieved under visible light illumination (>400 nm). Moreover, we have discovered that the photocatalytic activity for CO<sub>2</sub> reduction can be drastically enhanced by incorporating a small amount of Mg dopant. The definitive role of Mg dopant in Ga\u00ad(In)\u00adN, at both the atomic and device levels, has been identified. This study reveals the potential of III-nitride semiconductor nanostructures in solar-powered reduction of CO<sub>2</sub> into hydrocarbon fuels.'

--- a/tests/share/normalize/test_xml.py
+++ b/tests/share/normalize/test_xml.py
@@ -8,7 +8,8 @@ EXAMPLE = '''
     <id>http://arxiv.org/abs/cond-mat/0102536v1</id>
     <updated>2001-02-28T20:12:09Z</updated>
     <published>2001-02-28T20:12:09Z</published>
-    <title>Impact of Electron-Electron Cusp on Configuration Interaction Energies</title>
+    <title>Impact of Electron-Electron Cusp
+    on Configuration Interaction Energies</title>
     <summary>  The effect of the electron-electron cusp on the convergence of configuration
 interaction (CI) wave functions is examined. By analogy with the
 pseudopotential approach for electron-ion interactions, an effective
@@ -103,4 +104,9 @@ class TestParser:
 
         assert isinstance(parsed, dict)
         assert parsed['@type'] == 'preprint'
-        assert ctx.pool[parsed]['extra'] == {'comment': '11 pages, 6 figures, 3 tables, LaTeX209, submitted to The Journal of\n  Chemical Physics', 'journal_ref': 'J. Chem. Phys. 115, 1626 (2001)'}
+        normalized = ctx.pool[parsed]
+        assert normalized['extra'] == {'comment': '11 pages, 6 figures, 3 tables, LaTeX209, submitted to The Journal of\n  Chemical Physics', 'journal_ref': 'J. Chem. Phys. 115, 1626 (2001)'}
+
+        # no newlines, leading/trailing white space, or multiple spaces
+        assert normalized['title'] == 'Impact of Electron-Electron Cusp on Configuration Interaction Energies'
+        assert normalized['description'] == 'The effect of the electron-electron cusp on the convergence of configuration interaction (CI) wave functions is examined. By analogy with the pseudopotential approach for electron-ion interactions, an effective electron-electron interaction is developed which closely reproduces the scattering of the Coulomb interaction but is smooth and finite at zero electron-electron separation. The exact many-electron wave function for this smooth effective interaction has no cusp at zero electron-electron separation. We perform CI and quantum Monte Carlo calculations for He and Be atoms, both with the Coulomb electron-electron interaction and with the smooth effective electron-electron interaction. We find that convergence of the CI expansion of the wave function for the smooth electron-electron interaction is not significantly improved compared with that for the divergent Coulomb interaction for energy differences on the order of 1 mHartree. This shows that, contrary to popular belief, description of the electron-electron cusp is not a limiting factor, to within chemical accuracy, for CI calculations.'


### PR DESCRIPTION
When parsing a string value, remove leading/trailing white space and replace tabs, newlines, multiple spaces, etc. with a single space.