### PR TITLE
[Feature] Add ipdb to dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@
 
 pytest==3.0.2
 pytest-django==3.0.0
+ipdb==0.10.1


### PR DESCRIPTION
### Purpose
`ipdb` is required for running `./bin/share` commands

Note: cherry-picked from Christina #489 