### PR TITLE
[Fix][2.0.0] Un-hide Share relation fields in typed subclasses

### DIFF
--- a/tests/share/util/test_model_generator.py
+++ b/tests/share/util/test_model_generator.py
@@ -1,0 +1,21 @@
+import pytest
+
+from django.apps import apps
+
+
+@pytest.mark.parametrize('model_name, field_name', [
+    ('Funder', 'awards'),
+    ('Funder', 'award_versions'),
+    ('Funder', 'agent'),
+    ('Funder', 'creative_work'),
+    ('Contributor', 'contributed_through'),
+    ('Creator', 'order_cited'),
+    ('Person', 'given_name'),
+    ('Person', 'family_name'),
+    ('Person', 'additional_name'),
+    ('Person', 'suffix'),
+])
+def test_field_exists(model_name, field_name):
+    model = apps.get_model('share', model_name)
+    field = model._meta.get_field(field_name)
+    assert field


### PR DESCRIPTION
`ModelGenerator` didn't seem to be creating `ShareManyToManyField`s (e.g. `Funder` was missing `awards`), so I looked into it. Turns out django-typed-models modifies `_meta.get_fields()` on typed subclasses to filter out fields that don't belong, based on the fields given in the model definition. Share related fields (`ShareManyToManyField`, etc.) don't directly contribute to classes, they make instances of their base class that contribute instead. Since those don't equal the field defined on the model, they're filtered out of `get_fields`.

This adds a `ShareRelatedField` base class that keeps track of the fields that do a Share field's job, and compares equal to any of them, so they'll be accessible to the normalizers, validator, and whatever else needs it.