### PR TITLE
[2.0.0] Updated DataOne normalizer

### DIFF
--- a/providers/org/dataone/harvester.py
+++ b/providers/org/dataone/harvester.py
@@ -9,8 +9,8 @@ class DataOneHarvester(Harvester):
     url = 'https://cn.dataone.org/cn/v2/query/solr/'
 
     def do_harvest(self, start_date, end_date):
-        end_date = end_date.format('YYYY-MM-DDT00:00:00') + 'Z'
-        start_date = start_date.format('YYYY-MM-DDT00:00:00') + 'Z'
+        end_date = end_date.format('YYYY-MM-DDT00:00:00', formatter='alternative') + 'Z'
+        start_date = start_date.format('YYYY-MM-DDT00:00:00', formatter='alternative') + 'Z'
 
         url = furl(self.url).set(query_params={
             'q': 'dateModified:[{} TO {}]'.format(start_date, end_date),

--- a/providers/org/dataone/harvester.py
+++ b/providers/org/dataone/harvester.py
@@ -6,7 +6,7 @@ from share import Harvester
 
 
 class DataOneHarvester(Harvester):
-    url = 'https://cn.dataone.org/cn/v1/query/solr/'
+    url = 'https://cn.dataone.org/cn/v2/query/solr/'
 
     def do_harvest(self, start_date, end_date):
         end_date = end_date.format('YYYY-MM-DDT00:00:00') + 'Z'

--- a/providers/org/dataone/normalizer.py
+++ b/providers/org/dataone/normalizer.py
@@ -1,5 +1,6 @@
 from share.normalize import *
 
+
 class WorkIdentifier(Parser):
     uri = ctx
 

--- a/providers/org/dataone/normalizer.py
+++ b/providers/org/dataone/normalizer.py
@@ -41,14 +41,14 @@ class IsPartOf(Parser):
     related = Delegate(RelatedWork, ctx)
 
 
-class IsSupplementTo(Parser):
-    related = Delegate(RelatedWork, ctx)
-
-
-class Supplements(Parser):
-    schema = 'IsSupplementTo'
+class IsDocumentedBy(Parser):
+    schema = 'Documents'
 
     subject = Delegate(RelatedWork, ctx)
+
+
+class Documents(Parser):
+    related = Delegate(RelatedWork, ctx)
 
 
 class DataSet(Parser):
@@ -79,11 +79,11 @@ class DataSet(Parser):
             Maybe(XPath(ctx, "arr[@name='resourceMap']"), 'arr').str
         ),
         Map(
-            Delegate(IsSupplementTo),
+            Delegate(Documents),
             Maybe(XPath(ctx, "arr[@name='documents']"), 'arr').str
         ),
         Map(
-            Delegate(Supplements),
+            Delegate(IsDocumentedBy),
             Maybe(XPath(ctx, "arr[@name='isDocumentedBy']"), 'arr')['#text']
         ),
     )

--- a/providers/org/dataone/normalizer.py
+++ b/providers/org/dataone/normalizer.py
@@ -37,16 +37,24 @@ class Contributor(Parser):
 
 
 class CreativeWork(Parser):
+    # https://releases.dataone.org/online/api-documentation-v2.0/design/SearchMetadata.html#attribute-descriptions-and-notes
     title = Try(XPath(ctx, "str[@name='title']").str['#text'])
     description = Try(XPath(ctx, "str[@name='abstract']").str['#text'])
     date_updated = ParseDate(Try(XPath(ctx, "date[@name='dateModified']").date['#text']))
     date_published = ParseDate(Try(XPath(ctx, "date[@name='datePublished']").date['#text']))
-    contributors = Map(
-        Delegate(Contributor),
-        Maybe(XPath(ctx, "str[@name='author']"), 'str')['#text'],
-        Maybe(XPath(ctx, "arr[@name='origin']"), 'arr').str,
-        Maybe(XPath(ctx, "arr[@name='investigator']"), 'arr').str
+
+    related_agents = Concat(
+        Map(
+            Delegate(Creator),
+            Maybe(XPath(ctx, "str[@name='author']"), 'str')['#text'],
+        ),
+        Map(
+            Delegate(Contributor),
+            Maybe(XPath(ctx, "arr[@name='investigator']"), 'arr').str,
+            Maybe(XPath(ctx, "arr[@name='origin']"), 'arr').str, # TODO or 'originator'?
+        )
     )
+
     tags = Map(
         Delegate(ThroughTags),
         Maybe(XPath(ctx, "arr[@name='keywords']"), 'arr').str

--- a/providers/org/dataone/normalizer.py
+++ b/providers/org/dataone/normalizer.py
@@ -32,9 +32,12 @@ class Creator(Contributor):
 
 
 class RelatedWork(Parser):
-    schema = 'DataSet' # TODO or CreativeWork?
+    schema = 'DataSet'
 
-    identifiers = Map(Delegate(WorkIdentifier), ctx)
+    identifiers = Map(
+        Delegate(WorkIdentifier),
+        IRI(ctx)
+    )
 
 
 class IsPartOf(Parser):
@@ -84,7 +87,7 @@ class DataSet(Parser):
         ),
         Map(
             Delegate(IsDocumentedBy),
-            Maybe(XPath(ctx, "arr[@name='isDocumentedBy']"), 'arr')['#text']
+            Maybe(XPath(ctx, "arr[@name='isDocumentedBy']"), 'arr').str
         ),
     )
 

--- a/providers/org/dataone/normalizer.py
+++ b/providers/org/dataone/normalizer.py
@@ -1,18 +1,7 @@
 from share.normalize import *
 
-
-class Link(Parser):
-    url = ctx
-    type = RunPython('get_link_type', ctx)
-
-    def get_link_type(self, link):
-        if 'cn.dataone.org' in link:
-            return 'provider'
-        return 'misc'
-
-
-class ThroughLinks(Parser):
-    link = Delegate(Link, ctx)
+class WorkIdentifier(Parser):
+    uri = ctx
 
 
 class Tag(Parser):
@@ -23,21 +12,47 @@ class ThroughTags(Parser):
     tag = Delegate(Tag, ctx)
 
 
+class Agent(Parser):
+    schema = GuessAgentType(ctx)
+
+    name = ctx
+
+
 class Person(Parser):
-    given_name = ParseName(ctx).first
-    family_name = ParseName(ctx).last
-    additional_name = ParseName(ctx).middle
-    suffix = ParseName(ctx).suffix
+    name = ctx
 
 
 class Contributor(Parser):
+    agent = Delegate(Person, ctx)
+    cited_as = ctx
+
+
+class Creator(Contributor):
     order_cited = ctx('index')
-    cited_name = ctx
-    person = Delegate(Person, ctx)
 
 
-class CreativeWork(Parser):
-    # https://releases.dataone.org/online/api-documentation-v2.0/design/SearchMetadata.html#attribute-descriptions-and-notes
+class RelatedWork(Parser):
+    schema = 'DataSet' # TODO or CreativeWork?
+
+    identifiers = Map(Delegate(WorkIdentifier), ctx)
+
+
+class IsPartOf(Parser):
+    related = Delegate(RelatedWork, ctx)
+
+
+class IsSupplementTo(Parser):
+    related = Delegate(RelatedWork, ctx)
+
+
+class Supplements(Parser):
+    schema = 'IsSupplementTo'
+
+    subject = Delegate(RelatedWork, ctx)
+
+
+class DataSet(Parser):
+    # https://releases.dataone.org/online/api-documentation-v2.0/design/SearchMetadata.html
     title = Try(XPath(ctx, "str[@name='title']").str['#text'])
     description = Try(XPath(ctx, "str[@name='abstract']").str['#text'])
     date_updated = ParseDate(Try(XPath(ctx, "date[@name='dateModified']").date['#text']))
@@ -51,17 +66,40 @@ class CreativeWork(Parser):
         Map(
             Delegate(Contributor),
             Maybe(XPath(ctx, "arr[@name='investigator']"), 'arr').str,
-            Maybe(XPath(ctx, "arr[@name='origin']"), 'arr').str, # TODO or 'originator'?
+        ),
+        Map(
+            Delegate(Contributor.using(agent=Delegate(Agent))),
+            Maybe(XPath(ctx, "arr[@name='origin']"), 'arr').str,
+        )
+    )
+
+    related_works = Concat(
+        Map(
+            Delegate(IsPartOf),
+            Maybe(XPath(ctx, "arr[@name='resourceMap']"), 'arr').str
+        ),
+        Map(
+            Delegate(IsSupplementTo),
+            Maybe(XPath(ctx, "arr[@name='documents']"), 'arr').str
+        ),
+        Map(
+            Delegate(Supplements),
+            Maybe(XPath(ctx, "arr[@name='isDocumentedBy']"), 'arr')['#text']
+        ),
+    )
+
+    identifiers = Map(
+        Delegate(WorkIdentifier),
+        Map(
+            IRI(suppress_failure=True),
+            Maybe(XPath(ctx, "str[@name='dataUrl']"), 'str')['#text'],
+            Maybe(XPath(ctx, "str[@name='identifier']"), 'str')['#text']
         )
     )
 
     tags = Map(
         Delegate(ThroughTags),
         Maybe(XPath(ctx, "arr[@name='keywords']"), 'arr').str
-    )
-    links = Map(
-        Delegate(ThroughLinks),
-        Maybe(XPath(ctx, "str[@name='dataUrl']"), 'str')['#text']
     )
 
     class Extra:

--- a/share/normalize/links.py
+++ b/share/normalize/links.py
@@ -409,7 +409,7 @@ class TryLink(AbstractLink):
         except self._exceptions:
             return self._default
         except TypeError as err:
-            logger.warning('TypeError: {}. When trying to access {}'.format(err, self._chain))
+            logger.warning('TypeError: {}. When trying to access {}'.format(err, self._chain.chain()))
             return self._default
         return self.__anchor.run(val)
 
@@ -469,6 +469,9 @@ class XPathLink(AbstractLink):
         if len(elems) == 1 and not isinstance(self._next, (IndexLink, IteratorLink)):
             return elems[0]
         return elems
+
+    def __repr__(self):
+        return '<{}({!r})>'.format(self.__class__.__name__, self._xpath)
 
 
 class DelegateLink(AbstractLink):

--- a/share/normalize/links.py
+++ b/share/normalize/links.py
@@ -770,18 +770,19 @@ class URLLink(AbstractIRILink):
     PORTS = {80, 443, 20, 989}
     SCHEMES = {'http', 'https', 'ftp', 'ftps'}
     URL_RE = re.compile(r'\b({schemes})://[-a-z0-9@:%._\+~#=]{{2,256}}\.[a-z]{{2,6}}\b([-a-z0-9@:%_\+.~#?&//=]*)'.format(schemes='|'.join(SCHEMES)), flags=re.I)
+    SCHEMELESS_STARTS = ('www.', 'www2.')
 
     @classmethod
     def hint(cls, obj):
         if cls.URL_RE.search(obj) is not None:
             return 0.25
-        if obj[:4].lower() == 'www.':
+        if obj.lower().startswith(cls.SCHEMELESS_STARTS):
             return 0.1
         return 0
 
     def _parse(self, obj):
         match = self.URL_RE.search(obj)
-        if not match and obj[:4].lower() == 'www.':
+        if not match and obj.lower().startswith(self.SCHEMELESS_STARTS):
             match = self.URL_RE.search('http://{}'.format(obj))
         return super(URLLink, self)._parse(match.group(0))
 


### PR DESCRIPTION
- Update DataOne normalizer for 2.0.0
- Add `ARKLink`, since many DataOne identifiers are [ARKs](https://en.wikipedia.org/wiki/Archival_Resource_Key)
- Handle URLs that start with `www.` instead of a scheme, because that happens
- Add `Documents` work relation, but leave the migration off because it's covered by #497 