### PR TITLE
[2.0.0] Update USGS normalizer

### DIFF
--- a/providers/gov/usgs/normalizer.py
+++ b/providers/gov/usgs/normalizer.py
@@ -1,54 +1,90 @@
 from share.normalize import *
 
 
-class Person(Parser):
+class WorkIdentifier(Parser):
+    uri = IRI(ctx)
+
+
+class AgentIdentifier(Parser):
+    uri = IRI(ctx)
+
+
+class RelatedAgent(Parser):
+    schema = GuessAgentType(ctx, default='organization')
+
+    name = ctx
+
+
+class IsAffiliatedWith(Parser):
+    related = Delegate(RelatedAgent, ctx)
+
+
+class AbstractAgent(Parser):
+    identifiers = Map(
+        Delegate(AgentIdentifier),
+        Try(ctx.email),
+        SourceID(ctx.contributorId)
+    )
+
+    related_agents = Map(
+        Delegate(IsAffiliatedWith),
+        Try(ctx.affiliation.text)
+    )
+
+
+class Organization(AbstractAgent):
+    schema = GuessAgentType(ctx.text, default='organization')
+
+    name = ctx.text
+
+
+class Person(AbstractAgent):
     given_name = Maybe(ctx, 'given')
     family_name = Maybe(ctx, 'family')
 
 
-class Contributor(Parser):
+class Creator(Parser):
     order_cited = ctx('index')
-    cited_name = Join(Concat(Maybe(ctx, 'given'), Maybe(ctx, 'family')), joiner=' ')
-    person = Delegate(Person, ctx)
+    cited_as = ctx.text
+    agent = Delegate(Person, ctx)
 
 
-class Link(Parser):
-    url = ctx
-    type = RunPython('get_link_type', ctx)
+class PublisherAgent(Parser):
+    schema = GuessAgentType(ctx.publisher, default='organization')
 
-    def get_link_type(self, link):
-        if 'dx.doi.org' in link:
-            return 'doi'
-        if 'usgs.gov' in link:
-            return 'provider'
-        return 'misc'
-
-
-class ThroughLinks(Parser):
-    link = Delegate(Link, ctx)
+    name = ctx.publisher
+    location = Try(ctx.publisherLocation)
 
 
 class Publisher(Parser):
-    name = ctx
-
-
-class Association(Parser):
-    entity = Delegate(Publisher, ctx)
+    agent = Delegate(PublisherAgent, ctx)
 
 
 class CreativeWork(Parser):
+    schema = RunPython('get_schema', ctx.publicationType.text)
+
     title = ctx.title
     description = Maybe(ctx, 'docAbstract')
     date_updated = ParseDate(ctx.lastModifiedDate)
     date_published = ParseDate(ctx.displayToPublicDate)
     language = Maybe(ctx, 'language')
-    publishers = Map(Delegate(Association), Maybe(ctx, 'publisher'))
-    contributors = Map(Delegate(Contributor), Maybe(Maybe(ctx, 'contributors'), 'authors'))
-    links = Map(
-        Delegate(ThroughLinks),
-        DOI(Maybe(ctx, 'doi')),
-        RunPython('get_links', ctx.links),
-        RunPython('format_usgs_id_as_url', ctx.id)
+
+    related_agents = Concat(
+        Map(
+            Delegate(Creator),
+            Filter(lambda a: not a['corporation'], Try(ctx.contributors.authors))
+        ),
+        Map(
+            Delegate(Creator.using(agent=Delegate(Organization, ctx))),
+            Filter(lambda a: a['corporation'], Try(ctx.contributors.authors))
+        ),
+        Try(Delegate(Publisher, ctx))
+    )
+
+    identifiers = Map(
+        Delegate(WorkIdentifier),
+        RunPython('format_usgs_id_as_url', ctx.indexId),
+        Try(ctx.doi)
     )
 
     class Extra:
@@ -60,6 +96,7 @@ class CreativeWork(Parser):
         index_id = Maybe(ctx, 'indexId')
         ipds_id = Maybe(ctx, 'ipdsId')
         issue = Maybe(ctx, 'issue')
+        links = Maybe(ctx, 'links')
         online_only = Maybe(ctx, 'onlineOnly')
         other_geospatial = Maybe(ctx, 'otherGeospatial')
         publication_subtype = Maybe(ctx, 'publicationSubtype')
@@ -69,8 +106,20 @@ class CreativeWork(Parser):
         type = Maybe(ctx, 'type')
         volume = Maybe(ctx, 'volume')
 
+    def get_schema(self, publication_type):
+        return {
+            'Article': 'Article',
+            'Book': 'Book',
+            'Book chapter': 'Book',
+            'Conference Paper': 'ConferencePaper',
+            'Dataset': 'DataSet',
+            # 'Pamphlet':
+            # 'Patent':
+            'Report': 'Report',
+            'Speech': 'Presentation',
+            'Thesis': 'Thesis',
+            # 'Videorecording':
+        }.get(publication_type) or 'CreativeWork'
+
     def format_usgs_id_as_url(self, id):
         return 'https://pubs.er.usgs.gov/publication/{}'.format(id)
-
-    def get_links(self, links):
-        return [link['url'] for link in links if link.get('url')]

--- a/share/normalize/links.py
+++ b/share/normalize/links.py
@@ -24,7 +24,7 @@ from share.util import DictHashingDict
 logger = logging.getLogger(__name__)
 
 
-__all__ = ('ParseDate', 'ParseName', 'ParseLanguage', 'Trim', 'Concat', 'Map', 'Delegate', 'Maybe', 'XPath', 'Join', 'RunPython', 'Static', 'Try', 'Subjects', 'OneOf', 'Orcid', 'DOI', 'IRI', 'GuessAgentType', 'Filter')
+__all__ = ('ParseDate', 'ParseName', 'ParseLanguage', 'Trim', 'Concat', 'Map', 'Delegate', 'Maybe', 'XPath', 'Join', 'RunPython', 'Static', 'Try', 'Subjects', 'OneOf', 'Orcid', 'DOI', 'IRI', 'GuessAgentType', 'Filter', 'SourceID')
 
 
 #### Public API ####
@@ -119,6 +119,12 @@ def GuessAgentType(chain=None, default=None):
 
 def Filter(func, chain):
     return chain + FilterLink(func)
+
+
+def SourceID(chain=None):
+    if chain:
+        return chain + SourceIDLink()
+    return SourceIDLink()
 
 
 ### /Public API
@@ -618,19 +624,20 @@ class ISSNLink(AbstractIRILink):
         }
 
 
-class OAILink(AbstractIRILink):
-    OAI_RE = re.compile(r'\b(oai):((?:\w|[.-])+):(\S+)')
+class URNLink(AbstractIRILink):
+    SCHEMES = {'urn', 'oai'}
+    URN_RE = re.compile(r'\b({schemes}):((?:\w|[.-])+):(\S+)'.format(schemes='|'.join(SCHEMES)), flags=re.I)
 
     @classmethod
     def hint(cls, obj):
-        if cls.OAI_RE.search(obj) is not None:
+        if cls.URN_RE.search(obj) is not None:
             return 0.9
         return 0.0
 
     def _parse(self, obj):
-        match = self.OAI_RE.search(obj.lower())
+        match = self.URN_RE.search(obj.lower())
         if not match:
-            raise ValueError('\'{}\' is not a valid OAI Identifier.'.format(obj))
+            raise ValueError('\'{}\' is not a valid URN.'.format(obj))
 
         return {
             'scheme': match.group(1),
@@ -883,21 +890,22 @@ class GuessAgentTypeLink(AbstractLink):
     ORGANIZATION_KEYWORDS = (
         r'(^the\s|\sthe\s)',
         r'^[-A-Z]+$',
+        'bureau',
         'council',
         'center',
         'foundation',
         'group',
-        'society',
         'inc',
+        'society',
     )
     ORGANIZATION_RE = re.compile(r'\b({})\b'.format('|'.join(ORGANIZATION_KEYWORDS)), flags=re.I)
 
     INSTITUTION_KEYWORDS = (
-        'school',
-        'university',
-        'institution',
         'college',
         'institute',
+        'institution',
+        'school',
+        'university',
     )
     INSTITUTION_RE = re.compile(r'\b({})\b'.format('|'.join(INSTITUTION_KEYWORDS)), flags=re.I)
 
@@ -922,3 +930,10 @@ class FilterLink(AbstractLink):
 
     def execute(self, obj):
         return list(filter(self._func, obj))
+
+
+class SourceIDLink(AbstractLink):
+    URN_FORMAT = 'urn:share:{source}:{id}'
+
+    def execute(self, obj):
+        return self.URN_FORMAT.format(source=Context()._config.label, id=obj)

--- a/share/normalize/links.py
+++ b/share/normalize/links.py
@@ -936,4 +936,6 @@ class SourceIDLink(AbstractLink):
     URN_FORMAT = 'urn:share:{source}:{id}'
 
     def execute(self, obj):
-        return self.URN_FORMAT.format(source=Context()._config.label, id=obj)
+        id = urllib.parse.quote(str(obj))
+        source = Context()._config.label
+        return self.URN_FORMAT.format(source=source, id=id)

--- a/share/normalize/parsers.py
+++ b/share/normalize/parsers.py
@@ -71,13 +71,18 @@ class Parser(metaclass=ParserMeta):
 
     def parse(self):
         prev, Context().parser = Context().parser, self
+        try:
+            return self._do_parse()
+        finally:
+            Context().parser = prev
+
+    def _do_parse(self):
         if isinstance(self.schema, AbstractLink):
             schema = self.schema.chain()[0].run(self.context).lower()
         else:
             schema = self.schema
 
         if (self.context, schema) in ctx.pool:
-            Context().parser = prev
             logger.debug('Values (%s, %s) found in cache as %s', self.context, schema, ctx.pool[self.context, schema])
             return ctx.pool[self.context, schema]
 
@@ -116,8 +121,6 @@ class Parser(metaclass=ParserMeta):
                 inst['extra'][key] = val
         if not inst['extra']:
             del inst['extra']
-
-        Context().parser = prev
 
         ctx.pool[self.ref] = inst
         ctx.graph.append(inst)

--- a/tests/share/normalize/test_links.py
+++ b/tests/share/normalize/test_links.py
@@ -10,7 +10,7 @@ from share.normalize.links import GuessAgentTypeLink
 from share.normalize.links import IRILink
 from share.normalize.links import ISNILink
 from share.normalize.links import ISSNLink
-from share.normalize.links import OAILink
+from share.normalize.links import URNLink
 from share.normalize.links import OrcidLink
 
 UPPER_BOUND = pendulum.today().add(years=100).isoformat()
@@ -165,30 +165,39 @@ def test_arxiv_link(arxiv_id, result):
         assert ArXivLink().execute(arxiv_id)['IRI'] == result
 
 
-@pytest.mark.parametrize('oai_id, result', [
+@pytest.mark.parametrize('urn, result', [
     (None, TypeError('\'None\' is not of type str.')),
-    ('', ValueError('\'\' is not a valid OAI Identifier.')),
-    ('something else', ValueError('\'something else\' is not a valid OAI Identifier.')),
-    ('oai:missing.path', ValueError('\'oai:missing.path\' is not a valid OAI Identifier.')),
-    ('oai::blank', ValueError('\'oai::blank\' is not a valid OAI Identifier.')),
-    ('oai://cos.io/fun', ValueError('\'oai://cos.io/fun\' is not a valid OAI Identifier.')),
-    ('zenodo.com', ValueError('\'zenodo.com\' is not a valid OAI Identifier.')),
-    ('oai:invalid domain:this.is.stuff', ValueError('\'oai:invalid domain:this.is.stuff\' is not a valid OAI Identifier.')),
-    ('oai:domain.com:', ValueError('\'oai:domain.com:\' is not a valid OAI Identifier.')),
+    ('', ValueError('\'\' is not a valid URN.')),
+    ('something else', ValueError('\'something else\' is not a valid URN.')),
+    ('oai:missing.path', ValueError('\'oai:missing.path\' is not a valid URN.')),
+    ('oai::blank', ValueError('\'oai::blank\' is not a valid URN.')),
+    ('oai://cos.io/fun', ValueError('\'oai://cos.io/fun\' is not a valid URN.')),
+    ('zenodo.com', ValueError('\'zenodo.com\' is not a valid URN.')),
+    ('oai:invalid domain:this.is.stuff', ValueError('\'oai:invalid domain:this.is.stuff\' is not a valid URN.')),
+    ('oai:domain.com:', ValueError('\'oai:domain.com:\' is not a valid URN.')),
+    ('urn:missing.path', ValueError('\'urn:missing.path\' is not a valid URN.')),
+    ('urn::blank', ValueError('\'urn::blank\' is not a valid URN.')),
+    ('urn://cos.io/fun', ValueError('\'urn://cos.io/fun\' is not a valid URN.')),
+    ('urn:invalid domain:this.is.stuff', ValueError('\'urn:invalid domain:this.is.stuff\' is not a valid URN.')),
+    ('urn:domain.com:', ValueError('\'urn:domain.com:\' is not a valid URN.')),
     ('oai:cos.io:this.is.stuff', 'oai://cos.io/this.is.stuff'),
     ('oai:subdomain.cos.io:this.is.stuff', 'oai://subdomain.cos.io/this.is.stuff'),
     ('    oai:cos.io:stuff', 'oai://cos.io/stuff'),
     ('    oai:cos.io:stuff  ', 'oai://cos.io/stuff'),
     ('oai:cos.io:long:list:of:things', 'oai://cos.io/long:list:of:things'),
+    ('urn:share:this.is.stuff', 'urn://share/this.is.stuff'),
+    ('    urn:share:stuff', 'urn://share/stuff'),
+    ('    urn:share:stuff  ', 'urn://share/stuff'),
+    ('urn:share:long:list:of/things', 'urn://share/long:list:of/things'),
 ])
-def test_oai_link(oai_id, result):
+def test_urn_link(urn, result):
     if isinstance(result, Exception):
         with pytest.raises(type(result)) as e:
-            OAILink().execute(oai_id)
+            URNLink().execute(urn)
         assert e.value.args == result.args
     else:
         assert rfc3987.parse(result)  # Extra URL validation
-        assert OAILink().execute(oai_id)['IRI'] == result
+        assert URNLink().execute(urn)['IRI'] == result
 
 
 class TestIRILink:
@@ -442,8 +451,28 @@ class TestIRILink:
             'authority': 'cos.io',
             'IRI': 'oai://cos.io/long:list:of:things'
         }),
+        ('urn:cos.io:this.is.stuff', {
+            'scheme': 'urn',
+            'authority': 'cos.io',
+            'IRI': 'urn://cos.io/this.is.stuff'
+        }),
+        ('    urn:cos.io:stuff', {
+            'scheme': 'urn',
+            'authority': 'cos.io',
+            'IRI': 'urn://cos.io/stuff'
+        }),
+        ('    urn:cos.io:stuff  ', {
+            'scheme': 'urn',
+            'authority': 'cos.io',
+            'IRI': 'urn://cos.io/stuff'
+        }),
+        ('urn:cos.io:long:list:of/things', {
+            'scheme': 'urn',
+            'authority': 'cos.io',
+            'IRI': 'urn://cos.io/long:list:of/things'
+        }),
     ])
-    def test_oai_ids(self, input, output):
+    def test_urn_ids(self, input, output):
         return self._do_test(input, output)
 
     @pytest.mark.parametrize('input, output', [


### PR DESCRIPTION
Also:

- Add `SourceID` to normalizer tools.
  - For sources that give objects IDs that aren't URI-like or globally unique, make a URN that `IRI` will recognize.
  - Change `OAILink` to `URNLink`, which can accept URNs with scheme `urn` or `oai`
  - e.g. `SourceID(ctx.contributorID)` in the `gov.usgs` normalizer yields something like `urn:share:gov.usgs:1234`
- Make sure `Context().parser` is always reset when leaving a parser, even if leaving via exception
  - Allows wrapping `Try` around `Delegate`.