### PR TITLE
[2.0.0] Remove empties from a document before normalizing

### DIFF
--- a/share/normalize/oai.py
+++ b/share/normalize/oai.py
@@ -87,7 +87,7 @@ class OAICreator(OAIContributor):
 class OAIPublisher(Parser):
     schema = 'Publisher'
 
-    agent = tools.Delegate(OAIAgent.using(schema=tools.GuessAgentType(default='organization')), ctx)
+    agent = tools.Delegate(OAIAgent.using(schema=tools.GuessAgentType(ctx, default='organization')), ctx)
 
 
 class OAICreativeWork(Parser):


### PR DESCRIPTION
Remove strings that are empty, just white space, 'none', or 'empty'.