### PR TITLE
[WIP][2.0.0] Feature/generic disambiguator

### DIFF
--- a/share/change.py
+++ b/share/change.py
@@ -111,14 +111,13 @@ class ChangeGraph:
         for edge in self.relations.pop(source):
             if edge.subject == source:
                 self.relations[edge.related].remove(edge)
-                new_edge = GraphEdge(replacement, edge.related, edge._hint)
-                self.relations[replacement].add(new_edge)
-                self.relations[edge.related].add(new_edge)
+                subject, related = replacement, edge.related
             else:
                 self.relations[edge.subject].remove(edge)
-                new_edge = GraphEdge(edge.subject, replacement, edge._hint)
-                self.relations[edge.subject].add(new_edge)
-                self.relations[replacement].add(new_edge)
+                subject, related = edge.subject, replacement
+            new_edge = GraphEdge(subject, related, edge._hint)
+            self.relations[subject].add(new_edge)
+            self.relations[related].add(new_edge)
 
 
 class ChangeNode:

--- a/share/models/agents.py
+++ b/share/models/agents.py
@@ -57,6 +57,8 @@ class AbstractAgent(ShareObject, metaclass=TypedShareObjectMeta):
         if node.attrs.get('location'):
             node.attrs['location'] = strip_whitespace(node.attrs['location'])
 
+    disambiguation_fields = ('identifiers',)
+
     class Meta:
         db_table = 'share_agent'
         index_together = (

--- a/share/models/creative.py
+++ b/share/models/creative.py
@@ -28,6 +28,8 @@ class AbstractCreativeWork(ShareObject, metaclass=TypedShareObjectMeta):
     related_agents = ShareManyToManyField('AbstractAgent', through='AbstractAgentWorkRelation')
     related_works = ShareManyToManyField('AbstractCreativeWork', through='AbstractWorkRelation', through_fields=('subject', 'related'), symmetrical=False)
 
+    disambiguation_fields = ('identifiers',)
+
     @classmethod
     def normalize(self, node, graph):
         for k, v in tuple(node.attrs.items()):

--- a/share/models/identifiers.py
+++ b/share/models/identifiers.py
@@ -73,6 +73,9 @@ class WorkIdentifier(ShareObject):
     def __repr__(self):
         return '<{}({}, {})>'.format(self.__class__.__name__, self.uri, self.creative_work_id)
 
+    class Meta:
+        disambiguation_fields = ('uri',)
+
 
 class AgentIdentifier(ShareObject):
     uri = ShareURLField(unique=True)
@@ -106,3 +109,6 @@ class AgentIdentifier(ShareObject):
 
     def __repr__(self):
         return '<{}({}, {})>'.format(self.__class__.__name__, self.uri, self.agent_id)
+
+    class Meta:
+        disambiguation_fields = ('uri',)

--- a/share/models/identifiers.py
+++ b/share/models/identifiers.py
@@ -73,8 +73,7 @@ class WorkIdentifier(ShareObject):
     def __repr__(self):
         return '<{}({}, {})>'.format(self.__class__.__name__, self.uri, self.creative_work_id)
 
-    class Meta:
-        disambiguation_fields = ('uri',)
+    disambiguation_fields = ('uri',)
 
 
 class AgentIdentifier(ShareObject):
@@ -110,5 +109,4 @@ class AgentIdentifier(ShareObject):
     def __repr__(self):
         return '<{}({}, {})>'.format(self.__class__.__name__, self.uri, self.agent_id)
 
-    class Meta:
-        disambiguation_fields = ('uri',)
+    disambiguation_fields = ('uri',)

--- a/share/models/meta.py
+++ b/share/models/meta.py
@@ -18,6 +18,8 @@ logger = logging.getLogger('share.normalize')
 class Tag(ShareObject):
     name = models.TextField(unique=True)
 
+    disambiguation_fields = ('name',)
+
     @classmethod
     def normalize(cls, node, graph):
         tags = [
@@ -46,6 +48,8 @@ class Subject(models.Model):
     name = models.TextField(unique=True, db_index=True)
 
     objects = SubjectManager()
+
+    disambiguation_fields = ('name',)
 
     def __str__(self):
         return self.name

--- a/share/models/relations/agent.py
+++ b/share/models/relations/agent.py
@@ -8,6 +8,8 @@ class AbstractAgentRelation(ShareObject, metaclass=TypedShareObjectMeta):
     subject = ShareForeignKey('AbstractAgent', related_name='+')
     related = ShareForeignKey('AbstractAgent', related_name='+')
 
+    disambiguation_fields = ('subject', 'related')
+
     class Meta:
         db_table = 'share_agentrelation'
         unique_together = ('subject', 'related', 'type')

--- a/share/models/relations/agentwork.py
+++ b/share/models/relations/agentwork.py
@@ -14,6 +14,9 @@ class AbstractAgentWorkRelation(ShareObject, metaclass=TypedShareObjectMeta):
 
     cited_as = models.TextField(blank=True)
 
+    # TODO agent and/or cited_as
+    disambiguation_fields = ('creative_work', 'agent')
+
     @classmethod
     def normalize(self, node, graph):
         for k, v in tuple(node.attrs.items()):

--- a/share/models/relations/creative.py
+++ b/share/models/relations/creative.py
@@ -8,6 +8,8 @@ class AbstractWorkRelation(ShareObject, metaclass=TypedShareObjectMeta):
     subject = ShareForeignKey('AbstractCreativeWork', related_name='outgoing_creative_work_relations')
     related = ShareForeignKey('AbstractCreativeWork', related_name='incoming_creative_work_relations')
 
+    disambiguation_fields = ('subject', 'related')
+
     class Meta:
         db_table = 'share_workrelation'
         unique_together = ('subject', 'related', 'type')

--- a/tests/share/disambiguation/test_prune.py
+++ b/tests/share/disambiguation/test_prune.py
@@ -1,0 +1,86 @@
+import pytest
+
+from share.change import ChangeGraph
+from share.disambiguation import GraphDisambiguator
+
+@pytest.fixture
+def no_change_nodes():
+    return [{
+        '@id': '_:91011',
+        '@type': 'preprint',
+        'contributors': [{'@id': '_:5678', '@type': 'contributor'}],
+        'identifiers': [{'@id': '_:6789', '@type': 'workidentifier'}]
+    }, {
+        '@id': '_:5678',
+        '@type': 'contributor',
+        'agent': {
+            '@id': '_:1234',
+            '@type': 'person'
+        },
+        'creative_work': {
+            '@id': '_:91011',
+            '@type': 'preprint'
+        },
+    }, {
+        '@id': '_:1234',
+        '@type': 'person',
+        'given_name': 'Doe',
+        'family_name': 'Jane',
+    }, {
+        '@id': '_:6789',
+        '@type': 'workidentifier',
+        'uri': 'http://osf.io/guidguid',
+        'creative_work': {'@id': '_:91011', '@type': 'preprint'}
+    }]
+
+@pytest.fixture
+def dup_work_nodes():
+    return [{
+        '@id': '_:91011',
+        '@type': 'preprint',
+        'contributors': [{'@id': '_:5678', '@type': 'contributor'}],
+        'identifiers': [{'@id': '_:6789', '@type': 'workidentifier'}]
+    }, {
+        '@id': '_:5678',
+        '@type': 'contributor',
+        'agent': {
+            '@id': '_:1234',
+            '@type': 'person'
+        },
+        'creative_work': {
+            '@id': '_:91011',
+            '@type': 'preprint'
+        },
+    }, {
+        '@id': '_:1234',
+        '@type': 'person',
+        'given_name': 'Doe',
+        'family_name': 'Jane',
+    }, {
+        '@id': '_:6789',
+        '@type': 'workidentifier',
+        'uri': 'http://osf.io/guidguid',
+        'creative_work': {'@id': '_:91011', '@type': 'preprint'}
+    }, {
+        '@id': '_:91012',
+        '@type': 'creativework',
+        'identifiers': [{'@id': '_:6780', '@type': 'workidentifier'}]
+    }, {
+        '@id': '_:6780',
+        '@type': 'workidentifier',
+        'uri': 'http://osf.io/guidguid',
+        'creative_work': {'@id': '_:91012', '@type': 'creativework'}
+    }]
+
+
+
+class TestPruneChangeGraph:
+    def test_no_change(self, no_change_nodes):
+        graph = ChangeGraph(no_change_nodes, disambiguate=False)
+        GraphDisambiguator().prune(graph)
+        assert len(no_change_nodes) == len(graph.nodes)
+
+    def test_duplicate_works(self, dup_work_nodes):
+        graph = ChangeGraph(dup_work_nodes, disambiguate=False)
+        GraphDisambiguator().prune(graph)
+        assert len(dup_work_nodes) - 2 == len(graph.nodes)


### PR DESCRIPTION
- find and prune duplicates within a graph
  - [x] based on simple fields (e.g. `WorkIdentifier.uri`, `Tag.name`)
  - [x] based on one-to-many relations (e.g. `Article.identifiers`)
  - [ ] based on many-to-many relations (e.g. `Agent.work_relations`)
  - [x] based on type (two classes match if either is a subclass of the other)
- find matching instances in the database
  - [x] based on simple fields (e.g. `WorkIdentifier.uri`, `Tag.name`)
  - [ ] based on one-to-many relations (e.g. `Article.identifiers`)
  - [ ] based on many-to-many relations (e.g. `Agent.work_relations`)
  - [x] based on type (two classes match if either is a subclass of the other)