### PR TITLE
[WIP][2.0.0] Feature/disambigrelation

### DIFF
--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -49,9 +49,9 @@ class GraphDisambiguator:
                     if n.model != match.model and issubclass(n.model, match.model):
                         # remove the node with the less-specific class
                         logger.debug('Found duplicate! Keeping {}, pruning {}'.format(n, match))
-                        change_graph.replace(match, n)
                         self._cache.remove(match)
                         nodes.remove(match)
+                        change_graph.replace(match, n)
                         self._cache.add(n)
                     else:
                         logger.debug('Found duplicate! Keeping {}, pruning {}'.format(match, n))

--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 
 class GraphDisambiguator:
     def __init__(self):
-        self._node_cache = {}
-        self._query_cache = {}
+        self._cache = self.NodeCache()
 
     def prune(self, change_graph):
         # for each node in the graph, compare to each other node and remove duplicates
@@ -33,28 +32,27 @@ class GraphDisambiguator:
 
         while changed:
             changed = False
-            # TODO update only affected nodes instead of rebuilding the cache every loop
-            self._clear_cache()
+            # TODO update affected nodes after changes instead of rebuilding the cache every loop
+            self._cache.clear()
 
             for n in tuple(nodes):
                 if n.is_merge or (find_instances and n.instance):
                     continue
-                matches = self._get_cached_matches(n)
+                matches = self._cache.get_matches(n)
                 if len(matches) > 1:
                     # TODO?
                     raise NotImplementedError('Multiple matches that apparently didn\'t match each other?\nNode: {}\nMatches: {}'.format(node, matches))
 
-
                 if matches:
                     # remove duplicates within the graph
-                    match = matches[0]
+                    match = matches.pop()
                     if n.model != match.model and issubclass(n.model, match.model):
                         # remove the node with the less-specific class
                         logger.debug('Found duplicate! Keeping {}, pruning {}'.format(n, match))
-                        nodes.remove(match)
                         change_graph.replace(match, n)
-                        self._uncache_node(match)
-                        self._cache_node(n)
+                        self._cache.remove(match)
+                        nodes.remove(match)
+                        self._cache.add(n)
                     else:
                         logger.debug('Found duplicate! Keeping {}, pruning {}'.format(match, n))
                         nodes.remove(n)
@@ -73,7 +71,7 @@ class GraphDisambiguator:
                         n.instance = instance
                         logger.debug('Disambiguated {} to {}'.format(n, instance))
 
-                self._cache_node(n)
+                self._cache.add(n)
 
     def _disambiguweight(self, node):
         # Models with exactly 1 foreign key field (excluding those added by
@@ -84,63 +82,8 @@ class GraphDisambiguator:
         fk_count = sum(1 for f in node.model._meta.get_fields() if f.editable and (f.many_to_one or f.one_to_one) and f.name not in ignored)
         return fk_count if fk_count == 1 else -fk_count
 
-    def _get_query(self, node):
-        if node in self._query_cache:
-            return self._query_cache[node]
-
-        query = {
-            'attrs': {},
-            'relations': {}
-        }
-
-        fields = [
-            node.model._meta.get_field(f)
-            for f in node.model.disambiguation_fields
-        ]
-        for f in fields:
-            if f.is_relation:
-                if f.one_to_many:
-                    edges = node.related(name=f.name, many=True, forward=False)
-                    query['relations'][f.name] = [e.subject for e in edges]
-                elif f.many_to_many:
-                    # TODO
-                    raise NotImplementedError()
-            else:
-                if f.name not in node.attrs:
-                    raise ValueError('Missing field {} for disambiguation!\nNode: {}'.format(f.name, node))
-                value = node.attrs[f.name]
-                if value is None or value == '':
-                    raise ValueError('Blank field {} useless for disambiguation!\nNode: {}'.format(f.name, node))
-                query['attrs'][f.name] = value
-
-        self._query_cache[node] = query
-        return query
-
-    def _clear_cache(self):
-        self._node_cache.clear()
-        self._query_cache.clear()
-
-    def _cache_node(self, node):
-        concrete_model = node.model._meta.concrete_model
-        self._node_cache.setdefault(concrete_model, DictHashingDict()).setdefault(self._get_query(node), []).append(node)
-
-    def _uncache_node(self, node):
-        concrete_model = node.model._meta.concrete_model
-        try:
-            self._node_cache[concrete_model][self._get_query(node)].remove(node)
-        except (KeyError, ValueError):
-            logger.warn('Tried uncaching uncached node: {}'.format(node))
-
-    def _get_cached_matches(self, node):
-        concrete_model = node.model._meta.concrete_model
-        try:
-            matches = self._node_cache[concrete_model][self._get_query(node)]
-            return [m for m in matches if m != node and issubclass(m.model, node.model) or issubclass(node.model, m.model)]
-        except KeyError:
-            return []
-
     def _instance_for_node(self, node):
-        query = self._get_query(node)
+        info = self._cache.get_info(node)
         filter = {
             # TODO relations
             **query['attrs']
@@ -157,9 +100,116 @@ class GraphDisambiguator:
 
     def _matching_type_names(self, node):
         # list of all subclasses and superclasses of node.model
-        fmt = lambda t: t if t.startswith('share.') else 'share.{}'.format(t)
-        if node.model._meta.proxy:
-            type_names = node.model.get_types() + [fmt(m._meta.model_name) for m in node.model.mro() if issubclass(m, node.model._meta.concrete_model) and m._meta.proxy]
+        fmt = lambda model: 'share.{}'.format(model._meta.model_name)
+        concrete_model = node.model._meta.concrete_model
+        if concrete_model is node.model:
+            type_names = [fmt(node.model)]
         else:
-            type_names = [fmt(node.model._meta.model_name)]
+            type_names = node.model.get_types() + [fmt(m) for m in node.model.__mro__ if issubclass(m, concrete_model) and m._meta.proxy]
         return set(type_names)
+
+
+    class NodeCache:
+        def __init__(self):
+            self._node_cache = {}
+            self._info_cache = {}
+
+        def clear(self):
+            self._node_cache.clear()
+            self._info_cache.clear()
+
+        def get_info(self, node):
+            try:
+                return self._info_cache[node]
+            except KeyError:
+                info = self.NodeInfo(node)
+                self._info_cache[node] = info
+                return info
+
+        def add(self, node):
+            info = self.get_info(node)
+            model_cache = self._node_cache.setdefault(node.model._meta.concrete_model, DictHashingDict())
+            if info.any:
+                all_cache = model_cache.setdefault(info.all, DictHashingDict())
+                for item in info.any.items():
+                    all_cache.setdefault(item, []).append(node)
+            elif info.all:
+                model_cache.setdefault(info.all, []).append(node)
+            else:
+                logger.debug('Nothing to disambiguate on. Ignoring node {}'.format(node))
+
+        def remove(self, node):
+            info = self.get_info(node)
+            try:
+                all_cache = self._node_cache[node.model._meta.concrete_model][info.all]
+                if info.any:
+                    for item in info.any.items():
+                        all_cache[item].remove(node)
+                else:
+                    all_cache.remove(node)
+            except (KeyError, ValueError) as ex:
+                raise ValueError('Could not remove node from cache: Node {} not found!'.format(node)) from ex
+
+        def get_matches(self, node):
+            info = self.get_info(node)
+            matches = set()
+            try:
+                model_cache = self._node_cache[node.model._meta.concrete_model]
+                matches_all = model_cache[info.all]
+                if info.any:
+                    for item in info.any.items():
+                        matches.update(matches_all.get(item, []))
+                elif info.all:
+                    matches.update(matches_all)
+                return [m for m in matches if m != node and issubclass(m.model, node.model) or issubclass(node.model, m.model)]
+            except KeyError:
+                return []
+
+        # TODO better name
+        class NodeInfo:
+            def __init__(self, node):
+                self._node = node
+                self.all = self._all()
+                self.any = self._any()
+
+            def _all(self):
+                try:
+                    all = self._node.model.Disambiguation.all
+                except AttributeError:
+                    return {}
+                values = {f: self._field_value(f) for f in all}
+                missing = [f for f, v in values.items() if v is None]
+                if missing:
+                    logger.debug('Missing required fields for disambiguation!\nNode: {}\nMissing: {}'.format(self._node, missing))
+                    return {}
+                return values
+
+            def _any(self):
+                try:
+                    any = self._node.model.Disambiguation.any
+                except AttributeError:
+                    return {}
+                return {f: self._field_value(f, nested=True) for f in any}
+
+            def _field_value(self, field_name, nested=False):
+                if isinstance(field_name, (list, tuple)):
+                    if nested:
+                        return tuple(self._field_value(f) for f in field_name)
+                    else:
+                        raise ValueError('Disambiguation info cannot be nested for `all`, and only one level deep for `any`.')
+
+                field = self._node.model._meta.get_field(field_name)
+                if field.is_relation:
+                    if field.one_to_many:
+                        edges = self._node.related(name=field_name, forward=False)
+                        return tuple(e.subject for e in edges)
+                    elif field.many_to_many:
+                        # TODO
+                        raise NotImplementedError()
+                else:
+                    if field_name not in self._node.attrs:
+                        return None
+                    value = self._node.attrs[field.name]
+                    if value == '':
+                        return None
+                    return value

--- a/share/models/agents.py
+++ b/share/models/agents.py
@@ -57,7 +57,8 @@ class AbstractAgent(ShareObject, metaclass=TypedShareObjectMeta):
         if node.attrs.get('location'):
             node.attrs['location'] = strip_whitespace(node.attrs['location'])
 
-    disambiguation_fields = ('identifiers',)
+    class Disambiguation:
+        any = ('identifiers', 'work_relations')
 
     class Meta:
         db_table = 'share_agent'
@@ -95,3 +96,10 @@ def normalize_person(cls, node, graph):
         node.attrs['location'] = strip_whitespace(node.attrs['location'])
 
 Person.normalize = classmethod(normalize_person)  # noqa
+
+
+class UniqueNameDisambiguation:
+    any = AbstractAgent.Disambiguation.any + ('name',)
+
+Institution.Disambiguation = UniqueNameDisambiguation
+Organization.Disambiguation = UniqueNameDisambiguation

--- a/share/models/creative.py
+++ b/share/models/creative.py
@@ -28,13 +28,14 @@ class AbstractCreativeWork(ShareObject, metaclass=TypedShareObjectMeta):
     related_agents = ShareManyToManyField('AbstractAgent', through='AbstractAgentWorkRelation')
     related_works = ShareManyToManyField('AbstractCreativeWork', through='AbstractWorkRelation', through_fields=('subject', 'related'), symmetrical=False)
 
-    disambiguation_fields = ('identifiers',)
-
     @classmethod
     def normalize(self, node, graph):
         for k, v in tuple(node.attrs.items()):
             if isinstance(v, str):
                 node.attrs[k] = strip_whitespace(v)
+
+    class Disambiguation:
+        any = ('identifiers',)
 
     class Meta:
         db_table = 'share_creativework'

--- a/share/models/identifiers.py
+++ b/share/models/identifiers.py
@@ -73,7 +73,8 @@ class WorkIdentifier(ShareObject):
     def __repr__(self):
         return '<{}({}, {})>'.format(self.__class__.__name__, self.uri, self.creative_work_id)
 
-    disambiguation_fields = ('uri',)
+    class Disambiguation:
+        all = ('uri',)
 
 
 class AgentIdentifier(ShareObject):
@@ -109,4 +110,5 @@ class AgentIdentifier(ShareObject):
     def __repr__(self):
         return '<{}({}, {})>'.format(self.__class__.__name__, self.uri, self.agent_id)
 
-    disambiguation_fields = ('uri',)
+    class Disambiguation:
+        all = ('uri',)

--- a/share/models/meta.py
+++ b/share/models/meta.py
@@ -18,8 +18,6 @@ logger = logging.getLogger('share.normalize')
 class Tag(ShareObject):
     name = models.TextField(unique=True)
 
-    disambiguation_fields = ('name',)
-
     @classmethod
     def normalize(cls, node, graph):
         tags = [
@@ -42,6 +40,9 @@ class Tag(ShareObject):
     def __str__(self):
         return self.name
 
+    class Disambiguation:
+        all = ('name',)
+
 
 class SubjectManager(models.Manager):
     def get_by_natural_key(self, subject):
@@ -54,8 +55,6 @@ class Subject(models.Model):
 
     objects = SubjectManager()
 
-    disambiguation_fields = ('name',)
-
     def __str__(self):
         return self.name
 
@@ -64,6 +63,9 @@ class Subject(models.Model):
 
     def save(self):
         raise IntegrityError('Subjects are an immutable set! Do it in bulk, if you must.')
+
+    class Disambiguation:
+        all = ('name',)
 
 
 # Through Tables for all the things
@@ -75,6 +77,9 @@ class ThroughTags(ShareObject):
     class Meta:
         unique_together = ('tag', 'creative_work')
 
+    class Disambiguation:
+        all = ('tag', 'creative_work')
+
 
 class ThroughSubjects(ShareObject):
     subject = models.ForeignKey('Subject', related_name='work_relations')
@@ -82,3 +87,6 @@ class ThroughSubjects(ShareObject):
 
     class Meta:
         unique_together = ('subject', 'creative_work')
+
+    class Disambiguation:
+        all = ('subject', 'creative_work')

--- a/share/models/relations/agent.py
+++ b/share/models/relations/agent.py
@@ -8,7 +8,8 @@ class AbstractAgentRelation(ShareObject, metaclass=TypedShareObjectMeta):
     subject = ShareForeignKey('AbstractAgent', related_name='+')
     related = ShareForeignKey('AbstractAgent', related_name='+')
 
-    disambiguation_fields = ('subject', 'related')
+    class Disambiguation:
+        all = ('subject', 'related')
 
     class Meta:
         db_table = 'share_agentrelation'

--- a/share/models/relations/creative.py
+++ b/share/models/relations/creative.py
@@ -8,7 +8,8 @@ class AbstractWorkRelation(ShareObject, metaclass=TypedShareObjectMeta):
     subject = ShareForeignKey('AbstractCreativeWork', related_name='outgoing_creative_work_relations')
     related = ShareForeignKey('AbstractCreativeWork', related_name='incoming_creative_work_relations')
 
-    disambiguation_fields = ('subject', 'related')
+    class Disambiguation:
+        all = ('subject', 'related')
 
     class Meta:
         db_table = 'share_workrelation'

--- a/tests/share/normalize/test_models.py
+++ b/tests/share/normalize/test_models.py
@@ -192,10 +192,10 @@ class TestModelNormalization:
             assert node.attrs['uri'] == output
 
     @pytest.mark.parametrize('model, input, output', [
-        (models.Creator, {'cited_as': '   \t James\n Bond \t     ', 'related': {'person': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
-        (models.Contributor, {'cited_as': '   \t James\n Bond \t     ', 'related': {'person': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
-        (models.Creator, {'cited_as': '', 'related': {'person': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
-        (models.Contributor, {'cited_as': '', 'related': {'person': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
+        (models.Creator, {'cited_as': '   \t James\n Bond \t     ', 'related': {'agent': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
+        (models.Contributor, {'cited_as': '   \t James\n Bond \t     ', 'related': {'agent': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
+        (models.Creator, {'cited_as': '', 'related': {'agent': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
+        (models.Contributor, {'cited_as': '', 'related': {'agent': {'name': 'James   Bond'}, 'creative_work': {}}}, {'cited_as': 'James Bond'}),
     ])
     def test_normalize_agentworkrelation(self, model, input, output):
         graph, node = FakeGraph([]), FakeNode(input)


### PR DESCRIPTION
Define disambiguation behavior by adding a `Disambiguation` class to each model.
```python
class Disambiguation:
    all = ('field1', 'field2')
    any = ('field3', 'field4')
```
In order for two nodes to be considered duplicates, their `field1` and `field2` must be equal, and at least one of `field3` and `field4` must be equal.

TODO: lots more tests, there are many corners to explore