### PR TITLE
[Feature] Filter out emails at the Identifier manager

### DIFF
--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -112,7 +112,10 @@ class GraphDisambiguator:
         if info.matching_types:
             query &= Q(type__in=info.matching_types)
 
-        found = set(concrete_model.objects.filter(query))
+        try:
+            found = set(concrete_model.objects_unfiltered.filter(query))
+        except AttributeError:
+            found = set(concrete_model.objects.filter(query))
 
         if not found:
             logger.debug('No {}s found for {}'.format(concrete_model, query))

--- a/share/models/identifiers.py
+++ b/share/models/identifiers.py
@@ -34,12 +34,19 @@ __all__ = ('WorkIdentifier', 'AgentIdentifier')
 #    class Meta:
 #        abstract = True
 
+class FilteredEmailsManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().exclude(scheme='mailto')
+
 
 class WorkIdentifier(ShareObject):
     uri = ShareURLField(unique=True)
     host = models.TextField(editable=False)
     scheme = models.TextField(editable=False, help_text=_('A prefix to URI indicating how the following data should be interpreted.'))
     creative_work = ShareForeignKey('AbstractCreativeWork', related_name='identifiers')
+
+    objects = FilteredEmailsManager()
+    objects_unfiltered = models.Manager()
 
     @classmethod
     def normalize(self, node, graph):
@@ -82,6 +89,9 @@ class AgentIdentifier(ShareObject):
     host = models.TextField(editable=False)
     scheme = models.TextField(editable=False)
     agent = ShareForeignKey('AbstractAgent', related_name='identifiers')
+
+    objects = FilteredEmailsManager()
+    objects_unfiltered = models.Manager()
 
     @classmethod
     def normalize(self, node, graph):


### PR DESCRIPTION
- Filter emails from the default `*Identifier` managers
- Add `objects_unfiltered` manager for the disambiguator to use