### PR TITLE
Handle multiple disambiguation results when only one matches type.

### DIFF
--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -67,10 +67,12 @@ class GraphDisambiguator:
                     instance = self._instance_for_node(n)
                     if instance and isinstance(instance, list):
                         same_type = [i for i in instance if isinstance(i, n.model)]
-                        if len(same_type) != 1:
-                            # TODO after merging is fixed, add mergeaction change to graph
-                            logger.error('Found multiple matches %s for %s', instance, n)
+                        if not same_type:
+                            logger.error('Found multiple matches for %s, and none were of type %s: %s', n, n.model, instance)
                             raise NotImplementedError('Multiple matches found', n, instance)
+                        elif len(same_type) > 1:
+                            logger.error('Found multiple matches of type %s for %s: %s', n.model, n, same_type)
+                            raise NotImplementedError('Multiple matches found', n, same_type)
                         logger.warning('Found multiple matches for %s, but only one of type %s, fortunately.', n, n.model)
                         instance = same_type.pop()
                     if instance:

--- a/share/disambiguation.py
+++ b/share/disambiguation.py
@@ -66,9 +66,13 @@ class GraphDisambiguator:
                     # look for matches in the database
                     instance = self._instance_for_node(n)
                     if instance and isinstance(instance, list):
-                        # TODO after merging is fixed, add mergeaction change to graph
-                        logger.error('Found multiple matches %s for %s', instance, n)
-                        raise NotImplementedError('Multiple matches found', n, instance)
+                        same_type = [i for i in instance if isinstance(i, n.model)]
+                        if len(same_type) != 1:
+                            # TODO after merging is fixed, add mergeaction change to graph
+                            logger.error('Found multiple matches %s for %s', instance, n)
+                            raise NotImplementedError('Multiple matches found', n, instance)
+                        logger.warning('Found multiple matches for %s, but only one of type %s, fortunately.', n, n.model)
+                        instance = same_type.pop()
                     if instance:
                         changed = True
                         n.instance = instance

--- a/tests/share/disambiguation/test_agent.py
+++ b/tests/share/disambiguation/test_agent.py
@@ -49,9 +49,9 @@ initial = [
     ),
     Report(
         identifiers=[WorkIdentifier(4)],
-        related_agents=[
-            Person(name='Berkeley'),
-            Institution(name='Berkeley')
+        agent_relations=[
+            Creator(agent=Person(name='Berkeley')),
+            Publisher(agent=Institution(name='Berkeley'))
         ]
     )
 ]

--- a/tests/share/disambiguation/test_agent.py
+++ b/tests/share/disambiguation/test_agent.py
@@ -47,6 +47,13 @@ initial = [
             )
         ]
     ),
+    Report(
+        identifiers=[WorkIdentifier(4)],
+        related_agents=[
+            Person(name='Berkeley'),
+            Institution(name='Berkeley')
+        ]
+    )
 ]
 
 
@@ -66,6 +73,10 @@ class TestAgentDisambiguation:
         ([Preprint(related_agents=[Institution(8)])], models.Institution, 0),
         # organization where the name does not exist
         ([CreativeWork(related_agents=[Organization(name='Bill Gates')])], models.Organization, 1),
+        # organization and person exist with the same name
+        ([Organization(name='Berkeley')], models.Organization, 0),
+        # organization and person exist with the same name as incoming institution
+        ([Institution(name='Berkeley')], models.Institution, 0),
     ])
     def test_disambiguate(self, input, model, delta, Graph):
         initial_cg = ChangeGraph(Graph(*initial))

--- a/tests/share/disambiguation/test_agent.py
+++ b/tests/share/disambiguation/test_agent.py
@@ -75,8 +75,10 @@ class TestAgentDisambiguation:
         ([CreativeWork(related_agents=[Organization(name='Bill Gates')])], models.Organization, 1),
         # organization and person exist with the same name
         ([Organization(name='Berkeley')], models.Organization, 0),
-        # organization and person exist with the same name as incoming institution
+        # institution and person exist with the same name
         ([Institution(name='Berkeley')], models.Institution, 0),
+        # person doesn't disambiguate on name
+        ([Person(name='Berkeley')], models.Person, 1),
     ])
     def test_disambiguate(self, input, model, delta, Graph):
         initial_cg = ChangeGraph(Graph(*initial))


### PR DESCRIPTION
When disambiguating returns multiple instances, check how many of them are of the type we're looking for. If there's exactly one, use that instance. Otherwise, fail as before.

Lets the system function when a person has the same name as an organization/institution/consortium.