### PR TITLE
[SHARE-465][Feature] Add endpoint for model types

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -94,5 +94,6 @@ urlpatterns = [
     url(r'search/(?!.*_bulk\/?$)(?P<url_bits>.*)', csrf_exempt(views.ElasticSearchView.as_view()), name='search'),
 
     url(r'schema/?$', views.SchemaView.as_view(), name='schema'),
+    url(r'modeltypes/?$', views.ModelTypesView.as_view(), name='modeltypes'),
     *model_schema_patterns
 ] + router.urls

--- a/api/urls.py
+++ b/api/urls.py
@@ -94,6 +94,6 @@ urlpatterns = [
     url(r'search/(?!.*_bulk\/?$)(?P<url_bits>.*)', csrf_exempt(views.ElasticSearchView.as_view()), name='search'),
 
     url(r'schema/?$', views.SchemaView.as_view(), name='schema'),
-    url(r'modeltypes/?$', views.ModelTypesView.as_view(), name='modeltypes'),
+    url(r'schema/creativework/hierarchy/?$', views.ModelTypesView.as_view(), name='modeltypes'),
     *model_schema_patterns
 ] + router.urls

--- a/api/views/schema.py
+++ b/api/views/schema.py
@@ -1,12 +1,12 @@
 import re
 import os
 import yaml
-from collections import OrderedDict
 
 from rest_framework import views
 from rest_framework.response import Response
 
 from share import models
+from share.util import sort_dict_by_key
 from share.models.validators import JSONLDValidator
 
 __all__ = ('SchemaView', 'ModelSchemaView', 'ModelTypesView')
@@ -120,20 +120,9 @@ for model in schema_models:
 
 class ModelTypesView(views.APIView):
 
-    def __init__(self, *args, **kwargs):
-        super(ModelTypesView, self).__init__(*args, **kwargs)
-        yaml_file = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) + '/share/models/creative.yaml'
-        with open(yaml_file) as fobj:
-            self.model_specs = self.sort_dict(yaml.load(fobj))
-
-    def sort_dict(self, hierarchy):
-        types = OrderedDict()
-        for key, value in sorted(hierarchy.items()):
-            if isinstance(value, dict):
-                types[key] = self.sort_dict(value)
-            else:
-                types[key] = value
-        return types
+    yaml_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../share/models/creative.yaml')
+    with open(yaml_file) as fobj:
+        model_specs = sort_dict_by_key(yaml.load(fobj))
 
     def get(self, request, *args, **kwargs):
         return Response(self.model_specs)

--- a/api/views/share.py
+++ b/api/views/share.py
@@ -1,3 +1,6 @@
+import os
+import yaml
+
 from rest_framework import viewsets, views, status
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
@@ -127,3 +130,11 @@ class APIVersionRedirectView(RedirectView):
                 return HttpSmartResponsePermanentRedirect(url)
             return HttpSmartResponseRedirect(url)
         return http.HttpResponseGone()
+
+
+class ModelTypesView(views.APIView):
+    def get(self, request, *args, **kwargs):
+        yaml_file = os.path.abspath('../SHARE/share/models/creative.yaml')
+        with open(yaml_file) as fobj:
+            model_specs = yaml.load(fobj)
+        return Response(model_specs)

--- a/api/views/share.py
+++ b/api/views/share.py
@@ -1,6 +1,3 @@
-import os
-import yaml
-
 from rest_framework import viewsets, views, status
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
@@ -130,11 +127,3 @@ class APIVersionRedirectView(RedirectView):
                 return HttpSmartResponsePermanentRedirect(url)
             return HttpSmartResponseRedirect(url)
         return http.HttpResponseGone()
-
-
-class ModelTypesView(views.APIView):
-    def get(self, request, *args, **kwargs):
-        yaml_file = os.path.abspath('../SHARE/share/models/creative.yaml')
-        with open(yaml_file) as fobj:
-            model_specs = yaml.load(fobj)
-        return Response(model_specs)

--- a/share/util.py
+++ b/share/util.py
@@ -11,6 +11,16 @@ def strip_whitespace(string):
     return re.sub(WHITESPACE_RE, ' ', string).strip()
 
 
+def sort_dict_by_key(hierarchy):
+    types = OrderedDict()
+    for key, value in sorted(hierarchy.items()):
+        if isinstance(value, dict):
+            types[key] = sort_dict_by_key(value)
+        else:
+            types[key] = value
+    return types
+
+
 class InvalidID(Exception):
     def __init__(self, value, message='Invalid ID'):
         super().__init__(value, message)


### PR DESCRIPTION
## Purpose

Provide a simple way to get all of the creative work types.

## Changes

Add `modeltypes` endpoint that returns the contents of `creative.yaml`.

## Side effects

None