### PR TITLE
[SHARE-519][Feature] Allow Celery workers to be run in Gevent mode

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,13 @@
 import os
 import sys
 
+if os.environ.get('GEVENT') == '1':
+    from gevent import monkey
+    monkey.patch_all()
+
+    from psycogreen.gevent import patch_psycopg
+    patch_psycopg()
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 


### PR DESCRIPTION
  * Setting the env variable GEVENT=1 patches everything
  * Celery must be run with -P gevent
  * Deployments may now run a single harvester worker gevented to ~15
    greenlets
  * Forced LoggedTask and subclasses to be threadsafe