### PR TITLE
[SHARE-520][Feature] Encode all ids in API results

### DIFF
--- a/api/renderers.py
+++ b/api/renderers.py
@@ -244,7 +244,7 @@ class HideNullJSONAPIRenderer(JSONAPIRenderer):
     def build_json_resource_obj(cls, fields, resource, resource_instance, resource_name):
         resource_data = [
             ('type', resource_name),
-            ('id', cls.encode_id(resource_instance.pk, resource_name) if resource_instance else None),
+            ('id', cls.encode_id(resource_instance.pk, resource_instance._meta.model.__name__) if resource_instance else None),
             ('attributes', cls.extract_attributes(fields, resource)),
         ]
         relationships = cls.extract_relationships(fields, resource, resource_instance)

--- a/api/renderers.py
+++ b/api/renderers.py
@@ -3,20 +3,24 @@ import six
 from collections import OrderedDict
 
 from django.utils import encoding
+from django.apps import apps
 
 # from rest_framework.compat import SHORT_SEPARATORS, LONG_SEPARATORS, INDENT_SEPARATORS
 from rest_framework.renderers import JSONRenderer
 from rest_framework.settings import api_settings
 from rest_framework.utils import encoders
 from rest_framework import relations
-from rest_framework.serializers import BaseSerializer
+from rest_framework.serializers import BaseSerializer, Serializer, ListSerializer
 
 from rest_framework_json_api.renderers import JSONRenderer as JSONAPIRenderer
 from rest_framework_json_api import utils
 
+from share.util import IDObfuscator
+
 
 class HideNullJSONAPIRenderer(JSONAPIRenderer):
 
+    # override null behavior from JSONAPIRenderer
     @staticmethod
     def extract_attributes(fields, resource):
         data = OrderedDict()
@@ -46,11 +50,199 @@ class HideNullJSONAPIRenderer(JSONAPIRenderer):
 
         return utils.format_keys(data)
 
+    def encode_ids(relation_data):
+        if relation_data:
+            if not isinstance(relation_data, list):
+                relation_data = [relation_data]
+            for obj in relation_data:
+                obj['id'] = IDObfuscator.encode_id(int(obj['id']), apps.get_model('share', obj['type']))
+        return relation_data
+
+    def encode_id(resource_id, resource_type):
+        return encoding.force_text(IDObfuscator.encode_id(resource_id, apps.get_model('share', resource_type)))
+
+    # override ids in relationships from JSONAPIRenderer
+    @classmethod
+    def extract_relationships(cls, fields, resource, resource_instance):
+        # Avoid circular deps
+        from rest_framework_json_api.relations import ResourceRelatedField
+
+        data = OrderedDict()
+
+        # Don't try to extract relationships from a non-existent resource
+        if resource_instance is None:
+            return
+
+        for field_name, field in six.iteritems(fields):
+            # Skip URL field
+            if field_name == api_settings.URL_FIELD_NAME:
+                continue
+
+            # Skip fields without relations
+            if not isinstance(field, (relations.RelatedField, relations.ManyRelatedField, BaseSerializer)):
+                continue
+
+            source = field.source
+            relation_type = utils.get_related_resource_type(field)
+
+            if isinstance(field, relations.HyperlinkedIdentityField):
+                resolved, relation_instance = utils.get_relation_instance(resource_instance, source, field.parent)
+                if not resolved:
+                    continue
+                # special case for HyperlinkedIdentityField
+                relation_data = list()
+
+                # Don't try to query an empty relation
+                relation_queryset = relation_instance \
+                    if relation_instance is not None else list()
+
+                for related_object in relation_queryset:
+                    relation_data.append(
+                        OrderedDict([('type', relation_type), ('id', cls.encode_id(related_object.pk, relation_type))])
+                    )
+
+                data.update({field_name: {
+                    'links': {
+                        'related': resource.get(field_name)},
+                    'data': cls.encode_ids(relation_data),
+                    'meta': {
+                        'count': len(relation_data)
+                    }
+                }})
+                continue
+
+            if isinstance(field, ResourceRelatedField):
+                resolved, relation_instance = utils.get_relation_instance(resource_instance, source, field.parent)
+                if not resolved:
+                    continue
+
+                # special case for ResourceRelatedField
+                relation_data = {
+                    'data': cls.encode_ids(resource.get(field_name))
+                }
+
+                field_links = field.get_links(resource_instance)
+                relation_data.update(
+                    {'links': field_links}
+                    if field_links else dict()
+                )
+                data.update({field_name: relation_data})
+                continue
+
+            if isinstance(field, (relations.PrimaryKeyRelatedField, relations.HyperlinkedRelatedField)):
+                resolved, relation = utils.get_relation_instance(resource_instance, '%s_id' % source, field.parent)
+                if not resolved:
+                    continue
+                relation_id = relation if resource.get(field_name) else None
+                relation_data = {
+                    'data': (
+                        OrderedDict([('type', relation_type), ('id', cls.encode_id(relation_id, relation_type))])
+                        if relation_id is not None else None)
+                }
+
+                relation_data.update(
+                    {'links': {'related': resource.get(field_name)}}
+                    if isinstance(field, relations.HyperlinkedRelatedField) and resource.get(field_name) else dict()
+                )
+                data.update({field_name: relation_data})
+                continue
+
+            if isinstance(field, relations.ManyRelatedField):
+                resolved, relation_instance = utils.get_relation_instance(resource_instance, source, field.parent)
+                if not resolved:
+                    continue
+
+                if isinstance(field.child_relation, ResourceRelatedField):
+                    # special case for ResourceRelatedField
+                    relation_data = {
+                        'data': cls.encode_ids(resource.get(field_name))
+                    }
+
+                    field_links = field.child_relation.get_links(resource_instance)
+                    relation_data.update(
+                        {'links': field_links}
+                        if field_links else dict()
+                    )
+                    relation_data.update(
+                        {
+                            'meta': {
+                                'count': len(resource.get(field_name))
+                            }
+                        }
+                    )
+                    data.update({field_name: relation_data})
+                    continue
+
+                relation_data = list()
+                for nested_resource_instance in relation_instance:
+                    nested_resource_instance_type = (
+                        relation_type or
+                        utils.get_resource_type_from_instance(nested_resource_instance)
+                    )
+
+                    relation_data.append(OrderedDict([
+                        ('type', nested_resource_instance_type),
+                        ('id', cls.encode_id(nested_resource_instance.pk, nested_resource_instance_type))
+                    ]))
+                data.update({
+                    field_name: {
+                        'data': relation_data,
+                        'meta': {
+                            'count': len(relation_data)
+                        }
+                    }
+                })
+                continue
+
+            if isinstance(field, ListSerializer):
+                resolved, relation_instance = utils.get_relation_instance(resource_instance, source, field.parent)
+                if not resolved:
+                    continue
+
+                relation_data = list()
+
+                serializer_data = resource.get(field_name)
+                resource_instance_queryset = list(relation_instance)
+                if isinstance(serializer_data, list):
+                    for position in range(len(serializer_data)):
+                        nested_resource_instance = resource_instance_queryset[position]
+                        nested_resource_instance_type = (
+                            relation_type or
+                            utils.get_resource_type_from_instance(nested_resource_instance)
+                        )
+
+                        relation_data.append(OrderedDict([
+                            ('type', nested_resource_instance_type),
+                            ('id', cls.encode_id(nested_resource_instance.pk, nested_resource_instance_type))
+                        ]))
+
+                    data.update({field_name: {'data': relation_data}})
+                    continue
+
+            if isinstance(field, Serializer):
+                resolved, relation_instance = utils.get_relation_instance(resource_instance, source, field.parent)
+                if not resolved:
+                    continue
+
+                data.update({
+                    field_name: {
+                        'data': (
+                            OrderedDict([
+                                ('type', relation_type),
+                                ('id', cls.encode_id(resource_instance.pk, relation_type))
+                            ]) if resource.get(field_name) else None)
+                    }
+                })
+                continue
+
+        return utils.format_keys(data)
+
+    # override top level id from JSONAPIRenderer
     @classmethod
     def build_json_resource_obj(cls, fields, resource, resource_instance, resource_name):
         resource_data = [
             ('type', resource_name),
-            ('id', encoding.force_text(resource_instance.pk) if resource_instance else None),
+            ('id', cls.encode_id(resource_instance.pk, resource_name) if resource_instance else None),
             ('attributes', cls.extract_attributes(fields, resource)),
         ]
         relationships = cls.extract_relationships(fields, resource, resource_instance)

--- a/api/urls.py
+++ b/api/urls.py
@@ -60,7 +60,7 @@ class EndpointGenerator:
         self.register_url(subclass, generated_viewset)
 
     def register_url(self, subclass, viewset):
-        route_name = subclass.__name__.lower()
+        route_name = subclass._meta.verbose_name_plural.replace(" ", "")
         register_route(route_name, viewset)
 
 # generated model routes

--- a/api/urls.py
+++ b/api/urls.py
@@ -67,7 +67,7 @@ class EndpointGenerator:
 EndpointGenerator()
 
 # registration route
-register_route(r'registrations', views.ProviderRegistrationViewSet)
+register_route(r'sourceregistrations', views.ProviderRegistrationViewSet)
 
 # site banners route
 register_route(r'site_banners', views.SiteBannerViewSet)

--- a/share/models/creative.yaml
+++ b/share/models/creative.yaml
@@ -26,9 +26,11 @@ CreativeWork:
                 Registration: {}
                 Report: {}
                 # Section: {}
-                Thesis: {}
+                Thesis:
+                    verbose_name_plural: theses
                 WorkingPaper: {}
         Presentation: {}
         Retraction: {}
-        Software: {}
+        Software:
+            verbose_name_plural: software
         # Video: {}

--- a/share/models/meta.py
+++ b/share/models/meta.py
@@ -81,6 +81,7 @@ class ThroughTags(ShareObject):
 
     class Meta:
         unique_together = ('tag', 'creative_work')
+        verbose_name_plural = 'through tags'
 
     class Disambiguation:
         all = ('tag', 'creative_work')
@@ -92,6 +93,7 @@ class ThroughSubjects(ShareObject):
 
     class Meta:
         unique_together = ('subject', 'creative_work')
+        verbose_name_plural = 'through subjects'
 
     class Disambiguation:
         all = ('subject', 'creative_work')

--- a/share/models/relations/agent.yaml
+++ b/share/models/relations/agent.yaml
@@ -1,9 +1,12 @@
 AgentRelation:
     children:
         IsAffiliatedWith:
+            verbose_name_plural: is affiliated with
             description: The subject agent is officially attached or connected to the related agent.
             children:
                 IsEmployedBy:
+                    verbose_name_plural: is employed by
                     description: The subject agent is employed by the related agent.
                 IsMemberOf:
+                    verbose_name_plural: is member of
                     description: The subject agent is a member of the related group/organization.

--- a/share/models/relations/agentwork.py
+++ b/share/models/relations/agentwork.py
@@ -79,6 +79,7 @@ class ThroughAwards(ShareObject):
 
     class Meta:
         unique_together = ('funder', 'award')
+        verbose_name_plural = 'through awards'
 
     class Disambiguation:
         all = ('funder', 'award')

--- a/share/models/relations/creative.yaml
+++ b/share/models/relations/creative.yaml
@@ -1,10 +1,13 @@
 WorkRelation:
     children:
         IsPartOf:
+            verbose_name_plural: is part of
             description: The subject work is a portion, component, or child of the related work.
         IsSupplementTo:
+            verbose_name_plural: is supplement to
             description: The subject work supplements or enhances the related work.
         IsDerivedFrom:
+            verbose_name_plural: is derived from
             description: The subject work is derived from or based on the related work.
         Cites:
             description: The subject work cites the related work.
@@ -104,6 +107,7 @@ WorkRelation:
 #            description: The subject work refutes statements, ideas or conclusions presented in the related work.
 #            uris: ['http://purl.org/spar/cito/refutes']
         RepliesTo:
+            verbose_name_plural: replies to
             description: The subject work replies to statements, ideas or criticisms presented in the related work.
             uris: ['http://purl.org/spar/cito/repliesTo']
         Retracts:

--- a/share/util.py
+++ b/share/util.py
@@ -142,6 +142,8 @@ class ModelGenerator:
         models = {}
         for (name, mspec) in sorted(model_specs.items()):
             fields = mspec.get('fields', {})
+            verbose_name_plural = mspec.get('verbose_name_plural', None)
+
             model = type(name, (base,), {
                 **{fname: self._get_field(fspec) for (fname, fspec) in fields.items()},
                 '__doc__': mspec.get('description'),
@@ -150,6 +152,11 @@ class ModelGenerator:
             })
             models[name] = model
             models[model.VersionModel.__name__] = model.VersionModel
+
+            if verbose_name_plural:
+                model._meta.verbose_name_plural = verbose_name_plural
+            elif model._meta.verbose_name.endswith('s'):
+                model._meta.verbose_name_plural = model._meta.verbose_name
 
             children = mspec.get('children')
             if children:

--- a/tests/api/test_generated_endpoints.py
+++ b/tests/api/test_generated_endpoints.py
@@ -49,28 +49,28 @@ initial = [
 @pytest.mark.django_db
 class TestGeneratedEndpoints:
 
-    @pytest.mark.parametrize('generator, route, controlled_values', [
-        ([Institution(id=5, name='NIH')], 'institution', ['name']),
-        ([Organization(2, id=2)], 'organization', ['name']),
+    @pytest.mark.parametrize('generator, model, route, controlled_values', [
+        ([Institution(id=5, name='NIH')], 'institution', 'institutions', ['name']),
+        ([Organization(2, id=2)], 'organization', 'organizations', ['name']),
         ([CreativeWork(
             id=2,
             identifiers=[WorkIdentifier(id=2)],
             agent_relations=[Funder(agent=Institution(id=5, name='NIH'))]
-        )], 'funder', ['citedAs']),
+        )], 'funder', 'funders', ['citedAs']),
         ([CreativeWork(
             id=2,
             identifiers=[WorkIdentifier(id=2)],
             related_works=[
                 Publication(11, id=11, identifiers=[WorkIdentifier(id=3)])
             ]
-        )], 'publication', ['title', 'description']),
+        )], 'publication', 'publications', ['title', 'description']),
         ([CreativeWork(
             id=2,
             identifiers=[WorkIdentifier(id=2)],
             agent_relations=[Creator(agent=Person(1, identifiers=[AgentIdentifier(14)]))]
-        )], 'person', ['name']),
+        )], 'person', 'people', ['name']),
     ])
-    def test_get_data(self, generator, route, controlled_values, client, Graph):
+    def test_get_data(self, generator, model, route, controlled_values, client, Graph):
         initial_cg = ChangeGraph(Graph(*initial))
         initial_cg.process(disambiguate=False)
         ChangeSet.objects.from_graph(initial_cg, NormalizedDataFactory().id).accept()
@@ -79,7 +79,7 @@ class TestGeneratedEndpoints:
         cg.process()
 
         for obj in cg.serialize():
-            if obj['@type'] == route:
+            if obj['@type'] == model:
                 expected_id = obj['@id']
                 expected = obj
 

--- a/tests/api/test_generated_endpoints.py
+++ b/tests/api/test_generated_endpoints.py
@@ -4,7 +4,6 @@ import re
 
 from share.change import ChangeGraph
 from share.models import ChangeSet
-from share.util import IDObfuscator
 
 from tests.share.models.factories import NormalizedDataFactory
 from tests.share.normalize.factories import *
@@ -89,7 +88,7 @@ class TestGeneratedEndpoints:
         actual = json.loads(response.content.decode(encoding='UTF-8'))
 
         assert response.status_code == 200
-        assert actual['data']['id'] == str(IDObfuscator.decode_id(expected_id))
+        assert actual['data']['id'] == expected_id
         assert actual['data']['attributes']['type'] == expected['@type']
         for value in controlled_values:
             assert actual['data']['attributes'][value] == expected[camelCase_to_underscore(value)]

--- a/tests/api/test_providerregistration.py
+++ b/tests/api/test_providerregistration.py
@@ -304,8 +304,8 @@ class TestPostProviderRegistration:
         if authorized:
             kwargs['HTTP_AUTHORIZATION'] = 'Bearer {}'.format(trusted_user.accesstoken_set.first())
 
-        assert response == client.post('/api/v2/registrations/', *args, **kwargs)
+        assert response == client.post('/api/v2/sourceregistrations/', *args, **kwargs)
 
     @pytest.mark.django_db
     def test_get_data(self, client):
-        assert client.get('/api/v2/registrations/').status_code == 401
+        assert client.get('/api/v2/sourceregistrations/').status_code == 401


### PR DESCRIPTION
## Purpose

Show encoded ids in API instead of pks.

## Changes

* Override `extract_relationships` from `JSONAPIRenderer`
* Update generated endpoint tests

## Side effects

None