### PR TITLE
[SHARE-393][Feature] Update Zenodo migrations so new user is not created

### DIFF
--- a/providers/org/zenodo/apps.py
+++ b/providers/org/zenodo/apps.py
@@ -1,4 +1,3 @@
-from django.utils.functional import cached_property
 
 from share.provider import OAIProviderAppConfig
 
@@ -10,8 +9,4 @@ class AppConfig(OAIProviderAppConfig):
     long_title = 'Zenodo'
     home_page = 'https://zenodo.org/oai2d'
     url = 'https://zenodo.org/oai2d'
-
-    @cached_property
-    def user(self):
-        from share.models import ShareUser
-        return ShareUser.objects.get(robot='providers.org.zenodo')
+    disabled = True

--- a/providers/org/zenodo/datacite/apps.py
+++ b/providers/org/zenodo/datacite/apps.py
@@ -1,3 +1,5 @@
+from django.utils.functional import cached_property
+
 from share.provider import ProviderAppConfig
 from .harvester import ZenodoHarvester
 from providers.org.datacite.normalizer import DataciteNormalizer
@@ -20,3 +22,8 @@ class AppConfig(ProviderAppConfig):
         'http://schema.datacite.org/oai/oai-1.0/': None,
         'http://www.openarchives.org/OAI/2.0/oai_dc/': None,
     }
+
+    @cached_property
+    def user(self):
+        from share.models import ShareUser
+        return ShareUser.objects.get(robot='providers.org.zenodo')

--- a/providers/org/zenodo/datacite/migrations/0001_initial.py
+++ b/providers/org/zenodo/datacite/migrations/0001_initial.py
@@ -15,12 +15,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            code=share.robot.RobotUserMigration('org.zenodo.datacite'),
-        ),
-        migrations.RunPython(
-            code=share.robot.RobotOauthTokenMigration('org.zenodo.datacite'),
-        ),
-        migrations.RunPython(
             code=share.robot.RobotScheduleMigration('org.zenodo.datacite'),
         ),
     ]


### PR DESCRIPTION
## Purpose

Only have Zenodo appear in sources once.

## Changes

* Removed new user creation from zenodo.datacite migration
* Moved user definition from zenodo to zenodo.datacite
* Add `disabled = True` to zenodo

## Side effects
None from this PR

The org.zenodo.datacite user has been deleted from staging which also deleted all of the data harvested by org.zenodo.datacite. The results still show up in elastic and 404 if clicked on.