### PR TITLE
[SHARE-393][Feature] Remove set query param when using resumption token

### DIFF
--- a/share/harvest/oai.py
+++ b/share/harvest/oai.py
@@ -66,10 +66,7 @@ class OAIHarvester(Harvester, metaclass=abc.ABCMeta):
 
     def fetch_page(self, url: furl, token: str=None) -> (list, str):
         if token:
-            url.remove(self.from_param)
-            url.remove(self.until_param)
-            url.remove('metadataPrefix')
-            url.args['resumptionToken'] = token
+            url.args = {'resumptionToken': token, 'verb': 'ListRecords'}
 
         while True:
             logger.info('Making request to {}'.format(url.url))


### PR DESCRIPTION
Prevents Zenodo from failing when there are resumption tokens.