### PR TITLE
[SHARE-520][Feature] Correct verbose_name_plural for repository type

### DIFF
--- a/share/models/creative.yaml
+++ b/share/models/creative.yaml
@@ -39,7 +39,8 @@ CreativeWork:
                     verbose_name_plural: theses
                 WorkingPaper: {}
         Presentation: {}
-        Repository: {}
+        Repository:
+            verbose_name_plural: repositories
         Retraction: {}
         Software:
             verbose_name_plural: software


### PR DESCRIPTION
`Repositorys` --> `Repositories`