### PR TITLE
[SHARE-572][Feature] Order contributors by order_cited in graphql.

### DIFF
--- a/share/graphql/work.py
+++ b/share/graphql/work.py
@@ -65,7 +65,7 @@ class AbstractCreativeWork(AbstractShareObject):
     def resolve_related_agents(self, limit=None, offset=None):
         if limit:
             offset = (offset or 0) + limit
-        return self.agent_relations.all()[offset:limit]
+        return self.agent_relations.order_by('order_cited')[offset:limit]
 
     @graphene.resolve_only_args
     def resolve_total_incoming_work_relations(self):


### PR DESCRIPTION
Sort contributors by `order_cited` in graphql endpoint, `None` last, so creators are listed in order on the work detail page, followed by all other contributors.

https://openscience.atlassian.net/browse/SHARE-572