### PR TITLE
[SHARE-497][SHARE-526][Task] Add a status/version endpoint to the API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ COPY ./ /code/
 
 RUN python manage.py collectstatic --noinput
 
+ARG GIT_TAG=
 ARG GIT_COMMIT=
+ENV VERSION ${GIT_TAG}
 ENV GIT_COMMIT ${GIT_COMMIT}
 
 CMD ["python", "manage.py", "--help"]

--- a/api/urls.py
+++ b/api/urls.py
@@ -91,6 +91,7 @@ model_schema_patterns = [
 ]
 
 urlpatterns = [
+    url(r'status/?', views.ServerStatusView.as_view(), name='status'),
     url(r'rss/?', views.CreativeWorksRSS(), name='rss'),
     url(r'atom/?', views.CreativeWorksAtom(), name='atom'),
     url(r'graph/?', GraphQLView.as_view(graphiql=True)),

--- a/api/views/share.py
+++ b/api/views/share.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework_json_api import serializers
 
 from django import http
+from django.conf import settings
 from django.views.decorators.http import require_GET
 from django.views.generic.base import RedirectView
 from django.shortcuts import get_object_or_404
@@ -139,3 +140,15 @@ class APIVersionRedirectView(RedirectView):
                 return HttpSmartResponsePermanentRedirect(url)
             return HttpSmartResponseRedirect(url)
         return http.HttpResponseGone()
+
+
+class ServerStatusView(views.APIView):
+    def get(self, request):
+        return Response({
+            'id': '1',
+            'type': 'Status',
+            'attributes': {
+                'status': 'up',
+                'version': settings.VERSION,
+            }
+        })

--- a/project/settings.py
+++ b/project/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import subprocess
 
 from django.utils.log import DEFAULT_LOGGING
 
@@ -34,6 +35,14 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'c^0=k9r3i2@kh=*=(w2r_-sc#fd!+b23y%)gs
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(os.environ.get('DEBUG', True))
+
+if 'VERSION' not in os.environ and DEBUG:
+    try:
+        VERSION = subprocess.check_output(['git', 'describe']).decode().strip()
+    except subprocess.CalledProcessError:
+        VERSION = 'UNKNOWN'
+else:
+    VERSION = os.environ.get('VERSION') or 'UNKNOWN'
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '').split(' ')
 

--- a/templates/rest_framework/api.html
+++ b/templates/rest_framework/api.html
@@ -2,7 +2,7 @@
     {% load rest_framework %}
     {% load staticfiles %}
 
-    {% block title %}SHARE Notify{% endblock %}
+    {% block title %}SHARE{% endblock %}
 
     {% block style %}
         {% block bootstrap_theme %}

--- a/tests/api/test_status.py
+++ b/tests/api/test_status.py
@@ -1,0 +1,19 @@
+from django.test import override_settings
+
+
+class TestAPIStatusView:
+
+    @override_settings(VERSION='TESTCASE')
+    def test_works(self, client):
+        resp = client.get('/api/v2/status/')
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'data': {
+                'id': '1',
+                'type': 'Status',
+                'attributes': {
+                    'status': 'up',
+                    'version': 'TESTCASE',
+                }
+            }
+        }


### PR DESCRIPTION
  * In DEBUG mode, if VERSION is not set it will be pulled from a git
    repo
  * The Dockerfile now accepts GIT_TAG which will be passed in as
    VERSION
  * Also removes "Notify" from browsable API page title