### PR TITLE
[Feature][Fix] Disambiguate relations using all matched instances

### DIFF
--- a/share/models/change.py
+++ b/share/models/change.py
@@ -66,13 +66,14 @@ class ChangeManager(FuzzyCountManager):
             'target_version_type': ContentType.objects.get_for_model(node.model.VersionModel, for_concrete_model=True),
         }
 
-        if not node.instance:
+        target = node.get_instance()
+        if not target:
             assert not node.is_merge
             attrs['type'] = Change.TYPE.create
         else:
             attrs['type'] = Change.TYPE.merge if node.is_merge else Change.TYPE.update
-            attrs['target_id'] = node.instance.pk
-            attrs['target_version_id'] = node.instance.version.pk
+            attrs['target_id'] = target.pk
+            attrs['target_version_id'] = target.version.pk
 
         change = Change(**attrs)
 

--- a/tests/share/disambiguation/test_prune.py
+++ b/tests/share/disambiguation/test_prune.py
@@ -69,7 +69,7 @@ class TestPruneChangeGraph:
         graph = ChangeGraph(Graph(*input))
         ChangeSet.objects.from_graph(graph, normalized_data_id).accept()
 
-        assert all(n.instance is None for n in graph.nodes)
+        assert all(not n.instances for n in graph.nodes)
         GraphDisambiguator().find_instances(graph)
-        assert all(n.instance for n in graph.nodes)
-        assert all(n.instance._meta.model_name == n.type for n in graph.nodes)
+        assert all(n.instances for n in graph.nodes)
+        assert all(n.get_instance()._meta.model_name == n.type for n in graph.nodes)

--- a/tests/share/normalize/test_normalize.py
+++ b/tests/share/normalize/test_normalize.py
@@ -206,7 +206,7 @@ class TestChangeNode:
     @pytest.mark.django_db
     def test_load_instance(self, graph):
         tag = factories.TagFactory()
-        assert graph.create(IDObfuscator.encode(tag), 'tag', {}).instance == tag
+        assert graph.create(IDObfuscator.encode(tag), 'tag', {}).instances == set([tag])
 
     @pytest.mark.django_db
     def test_unresolveable(self, graph):
@@ -231,8 +231,8 @@ class TestChangeNode:
 
     @pytest.mark.django_db
     def test_change_datetime_change(self, graph):
-        tag = factories.AbstractCreativeWorkFactory()
-        assert graph.create(IDObfuscator.encode(tag), 'tag', {'date_updated': pendulum.fromtimestamp(0).isoformat()}).change == {'date_updated': pendulum.fromtimestamp(0).isoformat()}
+        work = factories.AbstractCreativeWorkFactory()
+        assert graph.create(IDObfuscator.encode(work), work._meta.model_name, {'date_updated': pendulum.fromtimestamp(0).isoformat()}).change == {'date_updated': pendulum.fromtimestamp(0).isoformat()}
 
     @pytest.mark.django_db
     def test_change_extra(self, graph):
@@ -246,7 +246,7 @@ class TestChangeNode:
         ))
         graph.namespace = 'testing'
         tag = graph.create(None, 'tag', {'extra': {'Same': 'here', 'Overwrite': 'you', 'New key': 'here'}})
-        tag.instance = tag_model
+        tag.instances = set([tag_model])
         assert tag.change == {'extra': {
             'New key': 'here',
             'Overwrite': 'you',


### PR DESCRIPTION
Fixes a bug in merging.

If two works exist in the database:
* WorkA, with IdentifierA and TagA
* WorkB, with IdentifierB and TagB

Then adding a work with two identifiers (IdentifierA, IdentifierB) and two tags (TagA, TagB) will fail. It will correctly try to merge WorkA and WorkB, but the task fails adding a ThroughTag that is already created as part of the merge.

No longer.