### PR TITLE
[SHARE-643][Improvement] Add exact field for title

### DIFF
--- a/bots/elasticsearch/bot.py
+++ b/bots/elasticsearch/bot.py
@@ -98,7 +98,7 @@ class ElasticSearchBot(Bot):
                 'sources': {'type': 'string', 'index': 'not_analyzed', 'include_in_all': False},
                 'subjects': {'type': 'string', 'index': 'not_analyzed', 'include_in_all': False},
                 'tags': {'type': 'string', 'fields': EXACT_FIELD},
-                'title': {'type': 'string'},
+                'title': {'type': 'string', 'fields': EXACT_FIELD},
                 'type': {'type': 'string', 'index': 'not_analyzed', 'include_in_all': False},
                 'types': {'type': 'string', 'index': 'not_analyzed', 'include_in_all': False},
                 'withdrawn': {'type': 'boolean', 'include_in_all': False},


### PR DESCRIPTION
## Purpose

Currently titles are tokenized and the non-analyzed title is not available via elastic.

## Changes

Add exact field for title

## Side effects

Requires reindexing but since it's only adding a field, does not require a new index.