### PR TITLE
[SHARE-538][Feature][Fix] Fix some merging errors.

### DIFF
--- a/share/models/change.py
+++ b/share/models/change.py
@@ -154,6 +154,10 @@ class Change(models.Model):
         # Little bit of blind faith here that all requirements have been accepted
         assert self.change_set.status == ChangeSet.STATUS.pending, 'Cannot accept a change with status {}'.format(self.change_set.status)
         logger.debug('Accepting change node ({}, {})'.format(ContentType.objects.get_for_id(self.model_type_id), self.node_id))
+
+        # Verify this is pointing at the right object
+        if self.target_id:
+            self.target = self.target_type.model_class().objects.get_canonical(self.target_id)
         ret = self._accept(save)
 
         if save:

--- a/tests/share/changes/test_merge.py
+++ b/tests/share/changes/test_merge.py
@@ -92,6 +92,7 @@ def work_snapshot(work):
         'outgoing_related_works': {(r.type, r.related.id) for r in work.outgoing_creative_work_relations.filter(same_as_id__isnull=True)},
     }
 
+
 def agent_snapshot(agent):
     # refresh from DB, even if type has changed
     agent = agent._meta.concrete_model.objects.get(id=agent.id)

--- a/tests/share/changes/test_merge.py
+++ b/tests/share/changes/test_merge.py
@@ -29,7 +29,7 @@ initial_works = [
         tags=[Tag(name='Ghosts N Stuff')],
         identifiers=[WorkIdentifier(3)],
         related_agents=[
-            Person(5),
+            Person(1),
             Person(6),
             Person(7, identifiers=[AgentIdentifier(2)]),
             Organization(8, name='Aperture Science'),
@@ -84,13 +84,13 @@ def work_snapshot(work):
     }
     return {
         **attributes,
-        'tags': {t.name for t in work.tags.all()},
-        'identifiers': {i.uri for i in work.identifiers.all()},
-        'related_agents': {(r.type, r.agent.name) for r in work.agent_relations.all()},
-        'incoming_related_works': {(r.type, r.subject.title) for r in work.incoming_creative_work_relations.all()},
-        'outgoing_related_works': {(r.type, r.related.title) for r in work.outgoing_creative_work_relations.all()},
+        'concrete_type': 'share.abstractcreativework',
+        'tags': {t.name for t in work.tags.filter(same_as_id__isnull=True)},
+        'identifiers': {i.uri for i in work.identifiers.filter(same_as_id__isnull=True)},
+        'related_agents': {(r.type, r.agent.id) for r in work.agent_relations.filter(same_as_id__isnull=True)},
+        'incoming_related_works': {(r.type, r.subject.id) for r in work.incoming_creative_work_relations.filter(same_as_id__isnull=True)},
+        'outgoing_related_works': {(r.type, r.related.id) for r in work.outgoing_creative_work_relations.filter(same_as_id__isnull=True)},
     }
-
 
 def agent_snapshot(agent):
     # refresh from DB, even if type has changed
@@ -102,14 +102,30 @@ def agent_snapshot(agent):
     }
     return {
         **attributes,
-        'identifiers': {i.uri for i in agent.identifiers.all()},
-        'related_works': {(r.type, r.creative_work.title) for r in agent.work_relations.all()},
-        'incoming_related_agents': {(r.type, r.subject.title) for r in agent.incoming_agent_relations.all()},
-        'outgoing_related_agents': {(r.type, r.related.title) for r in agent.outgoing_agent_relations.all()},
+        'concrete_type': 'share.abstractagent',
+        'identifiers': {i.uri for i in agent.identifiers.filter(same_as_id__isnull=True)},
+        'related_works': {(r.type, r.creative_work.id) for r in agent.work_relations.filter(same_as_id__isnull=True)},
+        'incoming_related_agents': {(r.type, r.subject.id) for r in agent.incoming_agent_relations.filter(same_as_id__isnull=True)},
+        'outgoing_related_agents': {(r.type, r.related.id) for r in agent.outgoing_agent_relations.filter(same_as_id__isnull=True)},
     }
 
 
+def resolve_snapshot(snapshot):
+    def resolve_tuples(tuples, model):
+        return {(t[0], model.objects.get_canonical(t[1]).id) for t in tuples}
+    if snapshot['concrete_type'] == 'share.abstractcreativework':
+        snapshot['related_agents'] = resolve_tuples(snapshot['related_agents'], models.Agent)
+        snapshot['incoming_related_works'] = resolve_tuples(snapshot['incoming_related_works'], models.CreativeWork)
+        snapshot['outgoing_related_works'] = resolve_tuples(snapshot['outgoing_related_works'], models.CreativeWork)
+    elif snapshot['concrete_type'] == 'share.abstractagent':
+        snapshot['related_works'] = resolve_tuples(snapshot['related_works'], models.CreativeWork)
+        snapshot['incoming_related_agents'] = resolve_tuples(snapshot['incoming_related_agents'], models.Agent)
+        snapshot['outgoing_related_agents'] = resolve_tuples(snapshot['outgoing_related_agents'], models.Agent)
+
+
 def merge_snapshots(older, newer):
+    resolve_snapshot(older)
+    resolve_snapshot(newer)
     merged = {}
     for k, v in newer.items():
         if isinstance(v, set):
@@ -215,6 +231,34 @@ class TestMergingObjects:
         merged_snapshot = merge_snapshots(from_snapshot, into_snapshot)
         assert merged_snapshot == work_snapshot(into_work)
 
+    def test_implicitly_merge_with_same_existing_relations(self, Graph):
+        setup(Graph)
+        tag_name = 'science'
+        from_work, into_work = models.CreativeWork.objects.filter(tags__name=tag_name).order_by('date_modified')[:2]
+        from_snapshot = work_snapshot(from_work)
+        into_snapshot = work_snapshot(into_work)
+
+        merge_cg = ChangeGraph(Graph(
+            CreativeWork(
+                sparse=True,
+                id='_:foo',
+                identifiers=[
+                    WorkIdentifier(uri=from_work.identifiers.first().uri),
+                    WorkIdentifier(uri=into_work.identifiers.first().uri),
+                ],
+                tags=[
+                    Tag(name=tag_name),
+                ]
+            )
+        ))
+        merge_cg.process()
+        ChangeSet.objects.from_graph(merge_cg, NormalizedDataFactory().id).accept()
+
+        from_work.refresh_from_db()
+        assert from_work.same_as_id == into_work.id
+        merged_snapshot = merge_snapshots(from_snapshot, into_snapshot)
+        assert merged_snapshot == work_snapshot(into_work)
+
     def test_implicitly_merge_several_works(self, Graph):
         works = setup(Graph)
         snapshots = [work_snapshot(w) for w in works]
@@ -296,6 +340,28 @@ class TestMergingObjects:
         from_agent.refresh_from_db()
         assert from_agent.same_as_id == into_agent.id
         assert merge_snapshots(from_snapshot, into_snapshot) == agent_snapshot(into_agent)
+
+    def test_merge_agents_across_works(self, Graph):
+        setup(Graph)
+        merge_input = Graph(
+            CreativeWork(
+                sparse=True,
+                id='_:faoeu',
+                identifiers=[WorkIdentifier(3)],
+                related_agents=[
+                    Person(1, identifiers=[AgentIdentifier(1)]),
+                ]
+            )
+        )
+        agent_uri = next(n['uri'] for n in merge_input if n['@type'] == 'agentidentifier')
+        agent = models.Agent.objects.get(identifiers__uri=agent_uri)
+        assert agent.related_works.count() == 1
+
+        merge_cg = ChangeGraph(merge_input)
+        merge_cg.process()
+        ChangeSet.objects.from_graph(merge_cg, NormalizedDataFactory().id).accept()
+        agent = models.Agent.objects.get_canonical(agent.id)
+        assert agent.related_works.count() == 2
 
     def test_merged_names_not_unique(self, Graph):
         from_org, into_org = setup(Graph, filter_type=models.Organization)[:2]


### PR DESCRIPTION
Make disambiguation and merging more resilient when accepting changesets that (a) trigger a merge and (b) include objects related to the objects to be merged. For example:
- Given a work that has a contributor without an identifier: Push the work's payload a second time with an identifier on its contributor that causes the agent to merge.
- Given two works that have the same tag: Push one of the works a second time (including its tags) with a new identifier that causes the works to merge.

### Changes
- Don't stop disambiguating a node after it's matched one instance. It could match something else on a subsequent pass.
- When accepting a change, follow `target.same_as` in case it was merged into something else earlier in the changeset.
- Don't emit merge nodes for objects that will be implicitly merged by merging a work, agent, or award.

### Side effects
Disambiguating will be somewhat slower. It doesn't seem too bad locally, but something to watch for on a larger db.