### PR TITLE
[SHARE-653][Improvement] Display trusted users and robots on sources page

### DIFF
--- a/api/views/workflow.py
+++ b/api/views/workflow.py
@@ -36,7 +36,7 @@ class ProviderViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProviderSerializer
 
     def get_queryset(self):
-        queryset = ShareUser.objects.exclude(robot='').exclude(long_title='')
+        queryset = ShareUser.objects.exclude(long_title='').exclude(favicon='')
         sort = self.request.query_params.get("sort")
         if sort:
             return queryset.order_by(sort)

--- a/bots/elasticsearch/tasks.py
+++ b/bots/elasticsearch/tasks.py
@@ -121,13 +121,13 @@ class IndexSourceTask(AppTask):
     def bulk_stream(self, es_index):
         ShareUser = apps.get_model('share.ShareUser')
         opts = {'_index': es_index, '_type': 'sources'}
-        for source in ShareUser.objects.exclude(robot='').exclude(long_title='').all():
-            yield {'_op_type': 'index', '_id': source.robot, **self.serialize(source), **opts}
+        for source in ShareUser.objects.exclude(long_title='').exclude(favicon='').all():
+            yield {'_op_type': 'index', '_id': source.username, **self.serialize(source), **opts}
 
     def serialize(self, source):
         return {
-            'id': source.robot,
+            'id': source.username,
             'type': 'source',
             'name': safe_substr(source.long_title),
-            'short_name': safe_substr(source.robot)
+            'short_name': safe_substr(source.username)
         }

--- a/share/graphql/query.py
+++ b/share/graphql/query.py
@@ -41,7 +41,7 @@ class Query(graphene.ObjectType):
     @graphene.resolve_only_args
     def resolve_sources(self, limit=25, offset=0):
         # TODO Long title will need an index
-        return models.ShareUser.objects.exclude(robot='').exclude(long_title='').order_by('long_title')[offset:offset + limit]
+        return models.ShareUser.objects.exclude(long_title='').exclude(favicon='').order_by('long_title')[offset:offset + limit]
 
     def resolve_search(self, args, context, info):
         args.setdefault('from', 0)


### PR DESCRIPTION
## Purpose
Display trusted users as sources on the 'Sources' page.

## Changes
* Update the autocomplete on the sources page (requires the reindexing)
* Switch all instances of filtering by robot='' to favicon=''

## Side effects
The logic for which sources appear in the sources list (only on the sources page) changed. It is hard to tell which ones will appear on the production data set since it is based on each ShareUser's settings.

These updates require the ShareUsers to be reindexed in elasticsearch.