### PR TITLE
List sources that support a given prefix

### DIFF
--- a/share/harvesters/oai.py
+++ b/share/harvesters/oai.py
@@ -103,3 +103,12 @@ class OAIHarvester(BaseHarvester):
         url.args['metadataPrefix'] = self.metadata_prefix
         url.args['identifier'] = provider_id
         return etree.tostring(self.fetch_page(url)[0][0], encoding=str)
+
+    def metadata_formats(self):
+        url = furl(self.config.base_url)
+        url.args['verb'] = 'ListMetadataFormats'
+        resp = self.requests.get(url.url)
+        resp.raise_for_status()
+        parsed = etree.fromstring(resp.content)
+        formats = parsed.xpath('//ns0:metadataPrefix', namespaces=self.namespaces)
+        return [f.text for f in formats]

--- a/share/management/commands/oaisources.py
+++ b/share/management/commands/oaisources.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+
+from share.models import SourceConfig
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--prefix', type=str, help='Metadata prefix to filter by')
+
+    def handle(self, *args, **options):
+        prefix = options.get('prefix')
+
+        oai_configs = SourceConfig.objects.filter(harvester__key='oai').order_by('base_url').distinct('base_url').select_related('source')
+
+        errors = []
+        for config in oai_configs:
+            try:
+                if not prefix or prefix in config.get_harvester().metadata_formats():
+                    print('{} ({})'.format(config.source.name, config.base_url))
+            except Exception as e:
+                errors.append('{} ({}): {}'.format(config.source.name, config.base_url, e))
+
+        if errors:
+            print('\nErrors:')
+            for e in errors:
+                print(e)


### PR DESCRIPTION
Add `oaisources` command, which can list all OAI sources that have a given prefix in their `ListMetadataFormats` results. It's slow, and could be sped up considerably by making requests in parallel, if anyone ever feels like it.

```
$ ./manage.py oaisources --prefix=datacite
org.datacite (http://oai.datacite.org/oai)
org.zenodo (https://zenodo.org/oai2d)
```

I made this while working on #602, and it might be useful to prioritize transformers based on how often formats are used.