### PR TITLE
Remove version from figshare's long_title

### DIFF
--- a/share/sources/com.figshare/source.yaml
+++ b/share/sources/com.figshare/source.yaml
@@ -20,6 +20,6 @@ configs:
   transformer: com.figshare.v2
   transformer_kwargs: {}
 home_page: https://figshare.com/
-long_title: figshare v1
+long_title: figshare
 name: com.figshare
 user: providers.com.figshare


### PR DESCRIPTION
Old:
![screen shot 2017-03-28 at 12 20 20 pm](https://cloud.githubusercontent.com/assets/7131985/24419340/cd42c95e-13bc-11e7-8895-824b994e6669.png)

New:
![screen shot 2017-03-28 at 1 43 02 pm](https://cloud.githubusercontent.com/assets/7131985/24419339/cd3b843c-13bc-11e7-8f8f-017d52edf02e.png)