### PR TITLE
[SHARE-741][Bug] Update raw data endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -64,7 +64,7 @@ class ShareModelSerializer(serializers.ModelSerializer):
 class RawDatumSerializer(ShareModelSerializer):
     class Meta:
         model = models.RawDatum
-        fields = ('id', 'source', 'app_label', 'provider_doc_id', 'data', 'sha256', 'date_seen', 'date_harvested')
+        fields = ('id', 'suid', 'datum', 'sha256', 'date_modified', 'date_created', 'logs')
 
 
 class ProviderRegistrationSerializer(ShareModelSerializer):

--- a/api/views/workflow.py
+++ b/api/views/workflow.py
@@ -115,9 +115,9 @@ class RawDatumViewSet(viewsets.ReadOnlyModelViewSet):
             return RawDatum.objects.filter(
                 normalizeddata__changeset__changes__target_id=object_id,
                 normalizeddata__changeset__changes__target_type__model=object_type
-            ).distinct('id').select_related('source')
+            ).distinct('id').select_related('suid')
         else:
-            return RawDatum.objects.all().select_related('source')
+            return RawDatum.objects.all().select_related('suid')
 
 
 class V1DataView(views.APIView):

--- a/tests/api/test_readonly_endpoints.py
+++ b/tests/api/test_readonly_endpoints.py
@@ -1,0 +1,67 @@
+import json
+import pytest
+
+
+def get_test_data(endpoint_type):
+    test_data = {
+        'data': {
+            'type': endpoint_type,
+            'attributes': {
+                'data': {
+                    '@graph': [{
+                        '@type': 'Person',
+                        'given_name': 'Jim',
+                    }]
+                }
+            }
+        }
+    }
+    return test_data
+
+
+@pytest.mark.django_db
+class TestRawDataEndpoint:
+    endpoint = '/api/v2/rawdata/'
+
+    def test_status(self, client):
+        assert client.get(self.endpoint).status_code == 200
+
+    def test_post(self, client, trusted_user):
+        assert client.post(
+            self.endpoint,
+            json.dumps(get_test_data('RawData')),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION='Bearer ' + trusted_user.accesstoken_set.first().token,
+        ).status_code == 405
+
+
+@pytest.mark.django_db
+class TestSourcesEndpoint:
+    endpoint = '/api/v2/sources/'
+
+    def test_status(self, client):
+        assert client.get(self.endpoint).status_code == 200
+
+    def test_post(self, client, trusted_user):
+        assert client.post(
+            self.endpoint,
+            json.dumps(get_test_data('Source')),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION='Bearer ' + trusted_user.accesstoken_set.first().token,
+        ).status_code == 405
+
+
+@pytest.mark.django_db
+class TestSiteBannersEndpoint:
+    endpoint = '/api/v2/site_banners/'
+
+    def test_status(self, client):
+        assert client.get(self.endpoint).status_code == 200
+
+    def test_post(self, client, trusted_user):
+        assert client.post(
+            self.endpoint,
+            json.dumps(get_test_data('SiteBanner')),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION='Bearer ' + trusted_user.accesstoken_set.first().token,
+        ).status_code == 405


### PR DESCRIPTION
## Purpose
RawData endpoint was returning 500s.

## Changes
Updated `viewset` and `serializer` to reflect model changes.

Add status and not being able to push tests for:
- `/rawdata/`
- `/sources/`
- `/site_banner/`