### PR TITLE
[SHARE-563][Bug] Handle scroll api 500s

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -98,7 +98,14 @@ urlpatterns = [
     url(r'atom/?', views.CreativeWorksAtom(), name='atom'),
     url(r'graph/?', GraphQLView.as_view(graphiql=True)),
     url(r'userinfo/?', ensure_csrf_cookie(views.ShareUserView.as_view()), name='userinfo'),
-    url(r'search/(?!.*_bulk\/?$)(?P<url_bits>.*)', csrf_exempt(views.ElasticSearchView.as_view()), name='search'),
+
+    # only match _count, _search, _suggest requests
+    url(
+        r'search/(?!.*_bulk\/?$)(?P<url_bits>(_|[a-zA-Z]+/_)((?=search)|(?=count)|(?=suggest))[a-zA-Z]{5,7}/{0,1}$)',
+        csrf_exempt(views.ElasticSearchView.as_view()),
+        name='search'
+    ),
+    url(r'search/(?!.*_bulk\/?$)(?P<url_bits>.*)', csrf_exempt(views.ElasticSearch403View.as_view()), name='search_403'),
 
     url(r'schema/?$', views.SchemaView.as_view(), name='schema'),
     url(r'schema/creativework/hierarchy/?$', views.ModelTypesView.as_view(), name='modeltypes'),

--- a/api/urls.py
+++ b/api/urls.py
@@ -99,15 +99,17 @@ urlpatterns = [
     url(r'graph/?', GraphQLView.as_view(graphiql=True)),
     url(r'userinfo/?', ensure_csrf_cookie(views.ShareUserView.as_view()), name='userinfo'),
 
-    # only match _count, _search, _suggest requests
+    # only match _count and _search requests
     url(
-        r'search/(?!.*_bulk\/?$)(?P<url_bits>(_|[a-zA-Z]+/_)((?=search)|(?=count)|(?=suggest))[a-zA-Z]{5,7}/{0,1}$)',
+        r'search/(?P<url_bits>(_|[a-zA-Z]+/_)(?:search|count)/{0,1}$)',
         csrf_exempt(views.ElasticSearchView.as_view()),
         name='search'
     ),
+    # match _suggest requests
+    url(r'search/(?P<url_bits>(_|[a-zA-Z]+/_)(?:suggest)/{0,1}$)', csrf_exempt(views.ElasticSearchPostOnlyView.as_view()), name='search_post'),
     # match _mappings requests
-    url(r'search/(?P<url_bits>_mappings(/.+|$|/))', csrf_exempt(views.ElasticSearchView.as_view()), name='search'),
-    url(r'search/(?!.*_bulk\/?$)(?P<url_bits>.*)', csrf_exempt(views.ElasticSearch403View.as_view()), name='search_403'),
+    url(r'search/(?P<url_bits>_mappings(/.+|$|/))', csrf_exempt(views.ElasticSearchGetOnlyView.as_view()), name='search_get'),
+    url(r'search/(?P<url_bits>.*)', csrf_exempt(views.ElasticSearch403View.as_view()), name='search_403'),
 
     url(r'schema/?$', views.SchemaView.as_view(), name='schema'),
     url(r'schema/creativework/hierarchy/?$', views.ModelTypesView.as_view(), name='modeltypes'),

--- a/api/urls.py
+++ b/api/urls.py
@@ -101,15 +101,27 @@ urlpatterns = [
 
     # only match _count and _search requests
     url(
-        r'search/(?P<url_bits>(_|[a-zA-Z]+/_)(?:search|count)/{0,1}$)',
+        r'search/(?P<url_bits>(?:\w+/)?_(?:search|count)/?)$',
         csrf_exempt(views.ElasticSearchView.as_view()),
         name='search'
     ),
     # match _suggest requests
-    url(r'search/(?P<url_bits>(_|[a-zA-Z]+/_)(?:suggest)/{0,1}$)', csrf_exempt(views.ElasticSearchPostOnlyView.as_view()), name='search_post'),
+    url(
+        r'search/(?P<url_bits>(?:\w+/)?_(?:suggest)/?)$',
+        csrf_exempt(views.ElasticSearchPostOnlyView.as_view()),
+        name='search_post'
+    ),
     # match _mappings requests
-    url(r'search/(?P<url_bits>_mappings(/.+|$|/))', csrf_exempt(views.ElasticSearchGetOnlyView.as_view()), name='search_get'),
-    url(r'search/(?P<url_bits>.*)', csrf_exempt(views.ElasticSearch403View.as_view()), name='search_403'),
+    url(
+        r'search/(?P<url_bits>_mappings(/.+|$|/))',
+        csrf_exempt(views.ElasticSearchGetOnlyView.as_view()),
+        name='search_get'
+    ),
+    url(
+        r'search/(?P<url_bits>.*)',
+        csrf_exempt(views.ElasticSearch403View.as_view()),
+        name='search_403'
+    ),
 
     url(r'schema/?$', views.SchemaView.as_view(), name='schema'),
     url(r'schema/creativework/hierarchy/?$', views.ModelTypesView.as_view(), name='modeltypes'),

--- a/api/urls.py
+++ b/api/urls.py
@@ -105,6 +105,8 @@ urlpatterns = [
         csrf_exempt(views.ElasticSearchView.as_view()),
         name='search'
     ),
+    # match _mappings requests
+    url(r'search/(?P<url_bits>_mappings(/.+|$|/))', csrf_exempt(views.ElasticSearchView.as_view()), name='search'),
     url(r'search/(?!.*_bulk\/?$)(?P<url_bits>.*)', csrf_exempt(views.ElasticSearch403View.as_view()), name='search_403'),
 
     url(r'schema/?$', views.SchemaView.as_view(), name='schema'),

--- a/api/views/elasticsearch.py
+++ b/api/views/elasticsearch.py
@@ -14,6 +14,22 @@ from rest_framework.response import Response
 from api import authentication
 
 
+class ElasticSearch403View(views.APIView):
+    """
+    Elasticsearch endpoint for unsupported queries.
+    """
+    authentication_classes = (authentication.NonCSRFSessionAuthentication, )
+    parser_classes = (JSONParser,)
+    permission_classes = (AllowAny, )
+    renderer_classes = (JSONRenderer, )
+
+    def get(self, request, *args, **kwargs):
+        return http.HttpResponseForbidden()
+
+    def post(self, request, *args, **kwargs):
+        return http.HttpResponseForbidden()
+
+
 class ElasticSearchView(views.APIView):
     """
     Elasticsearch endpoint for SHARE Data.
@@ -29,28 +45,16 @@ class ElasticSearchView(views.APIView):
     renderer_classes = (JSONRenderer, )
 
     def get(self, request, *args, url_bits='', **kwargs):
-        # Handle scroll API requests
-        bits = list(filter(None, url_bits.split('/')))
-        if bits[-1] == 'scroll':
-            return http.HttpResponse(reason='Scroll is not supported.', status=501)
-        if len(bits) > 2:
-            return http.HttpResponseBadRequest()
         return self._handle_request(request, url_bits)
 
     def post(self, request, *args, url_bits='', **kwargs):
-        # Disallow posting to any non-search endpoint
-        bits = list(filter(None, url_bits.split('/')))
-        if bits[-1] == 'scroll':
-            return http.HttpResponse(reason='Scroll is not supported.', status=501)
-        if len(bits) > 2 or bits[-1] not in ('_count', '_search', '_suggest'):
-            return http.HttpResponseBadRequest()
         return self._handle_request(request, url_bits)
 
     def _handle_request(self, request, url_bits):
         params = request.query_params.copy()
 
         if 'scroll' in params:
-            return http.HttpResponse(reason='Scroll is not supported.', status=501)
+            return http.HttpResponseForbidden(reason='Scroll is not supported.')
 
         v = params.pop('v', None)
         index = settings.ELASTICSEARCH_INDEX

--- a/api/views/elasticsearch.py
+++ b/api/views/elasticsearch.py
@@ -30,6 +30,66 @@ class ElasticSearch403View(views.APIView):
         return http.HttpResponseForbidden()
 
 
+class ElasticSearchGetOnlyView(views.APIView):
+    """
+    Elasticsearch get only endpoint for SHARE Data.
+
+    - _mappings
+    """
+    authentication_classes = (authentication.NonCSRFSessionAuthentication, )
+    parser_classes = (JSONParser,)
+    permission_classes = (AllowAny, )
+    renderer_classes = (JSONRenderer, )
+
+    def get(self, request, *args, url_bits='', **kwargs):
+        params = request.query_params.copy()
+
+        v = params.pop('v', None)
+        index = settings.ELASTICSEARCH_INDEX
+        if v:
+            v = 'v{}'.format(v[0])
+            if v not in settings.ELASTICSEARCH_INDEX_VERSIONS:
+                return http.HttpResponseBadRequest('Invalid search index version')
+            index = '{}_{}'.format(index, v)
+        es_url = furl(settings.ELASTICSEARCH_URL).add(path=index, query_params=params).add(path=url_bits.split('/'))
+
+        if request.method == 'GET':
+            resp = requests.get(es_url)
+        else:
+            raise NotImplementedError()
+        return Response(status=resp.status_code, data=resp.json(), headers={'Content-Type': 'application/vnd.api+json'})
+
+
+class ElasticSearchPostOnlyView(views.APIView):
+    """
+    Elasticsearch post only endpoint for SHARE Data.
+
+    - _suggest
+    """
+    authentication_classes = (authentication.NonCSRFSessionAuthentication, )
+    parser_classes = (JSONParser,)
+    permission_classes = (AllowAny, )
+    renderer_classes = (JSONRenderer, )
+
+    def post(self, request, *args, url_bits='', **kwargs):
+        params = request.query_params.copy()
+
+        v = params.pop('v', None)
+        index = settings.ELASTICSEARCH_INDEX
+        if v:
+            v = 'v{}'.format(v[0])
+            if v not in settings.ELASTICSEARCH_INDEX_VERSIONS:
+                return http.HttpResponseBadRequest('Invalid search index version')
+            index = '{}_{}'.format(index, v)
+        es_url = furl(settings.ELASTICSEARCH_URL).add(path=index, query_params=params).add(path=url_bits.split('/'))
+
+        if request.method == 'POST':
+            resp = requests.post(es_url, json=request.data)
+        else:
+            raise NotImplementedError()
+        return Response(status=resp.status_code, data=resp.json(), headers={'Content-Type': 'application/vnd.api+json'})
+
+
 class ElasticSearchView(views.APIView):
     """
     Elasticsearch endpoint for SHARE Data.

--- a/tests/api/test_elasticsearch.py
+++ b/tests/api/test_elasticsearch.py
@@ -20,10 +20,10 @@ class TestElasticSearchProxy:
         assert client.delete('/api/v2/search/type/index/_thing').status_code == 405
 
     def test_cannot_access_bulk(self, client):
-        assert client.delete('/api/v2/search/_bulk').status_code == 404
-        assert client.delete('/api/v2/search/_bulk?test').status_code == 404
-        assert client.delete('/api/v2/search/type/_bulk?foo').status_code == 404
-        assert client.delete('/api/v2/search/type/index/_bulk').status_code == 404
+        assert client.delete('/api/v2/search/_bulk').status_code == 405
+        assert client.delete('/api/v2/search/_bulk?test').status_code == 405
+        assert client.delete('/api/v2/search/type/_bulk?foo').status_code == 405
+        assert client.delete('/api/v2/search/type/index/_bulk').status_code == 405
 
     def test_limitted_post(self, client):
         assert client.post('/api/v2/search/type').status_code == 403
@@ -56,11 +56,24 @@ class TestElasticSearchProxy:
             '/api/v2/search/type/_search',
             '/api/v2/search/type/_search/',
             '/api/v2/search/type/_suggest',
+            '/api/v2/search/type/_suggest/',
         )
         with mock.patch('api.views.elasticsearch.requests.post') as post:
             post.return_value = mock.Mock(status_code=200, json=lambda: {})
             for url in urls:
                 assert client.post(url, '{}', content_type='application/json').status_code == 200
+
+    def test_cannot_post(self, client):
+        urls = (
+            '/api/v2/search/_mappings/',
+            '/api/v2/search/_mappings',
+            '/api/v2/search/_mappings/creativeworks',
+            '/api/v2/search/_mappings/creativeworks/',
+        )
+        with mock.patch('api.views.elasticsearch.requests.post') as post:
+            post.return_value = mock.Mock(status_code=405, json=lambda: {})
+            for url in urls:
+                assert client.post(url, '{}', content_type='application/json').status_code == 405
 
     def test_get_search(self, client):
         urls = (
@@ -79,3 +92,15 @@ class TestElasticSearchProxy:
             get.return_value = mock.Mock(status_code=200, json=lambda: {})
             for url in urls:
                 assert client.get(url).status_code == 200
+
+    def test_cannot_get(self, client):
+        urls = (
+            '/api/v2/search/_suggest',
+            '/api/v2/search/_suggest/',
+            '/api/v2/search/type/_suggest',
+            '/api/v2/search/type/_suggest/',
+        )
+        with mock.patch('api.views.elasticsearch.requests.get') as get:
+            get.return_value = mock.Mock(status_code=405, json=lambda: {})
+            for url in urls:
+                assert client.get(url).status_code == 405

--- a/tests/api/test_elasticsearch.py
+++ b/tests/api/test_elasticsearch.py
@@ -1,5 +1,4 @@
 from unittest import mock
-import pytest
 
 
 class TestElasticSearchProxy:
@@ -63,17 +62,20 @@ class TestElasticSearchProxy:
             for url in urls:
                 assert client.post(url, '{}', content_type='application/json').status_code == 200
 
-    @pytest.mark.parametrize('url', (
-        '/api/v2/search/_search',
-        '/api/v2/search/_search/',
-        '/api/v2/search/type/_count',
-        '/api/v2/search/type/_count/',
-        '/api/v2/search/type/_search',
-        '/api/v2/search/type/_search/',
-        '/api/v2/search/_mappings/',
-        '/api/v2/search/_mappings',
-        '/api/v2/search/_mappings/creativeworks',
-        '/api/v2/search/_mappings/creativeworks/',
-    ))
-    def test_get_search(self, client, url):
-        assert client.get(url).status_code == 200
+    def test_get_search(self, client):
+        urls = (
+            '/api/v2/search/_search',
+            '/api/v2/search/_search/',
+            '/api/v2/search/type/_count',
+            '/api/v2/search/type/_count/',
+            '/api/v2/search/type/_search',
+            '/api/v2/search/type/_search/',
+            '/api/v2/search/_mappings/',
+            '/api/v2/search/_mappings',
+            '/api/v2/search/_mappings/creativeworks',
+            '/api/v2/search/_mappings/creativeworks/',
+        )
+        with mock.patch('api.views.elasticsearch.requests.get') as get:
+            get.return_value = mock.Mock(status_code=200, json=lambda: {})
+            for url in urls:
+                assert client.get(url).status_code == 200

--- a/tests/api/test_elasticsearch.py
+++ b/tests/api/test_elasticsearch.py
@@ -26,24 +26,24 @@ class TestElasticSearchProxy:
         assert client.delete('/api/v2/search/type/index/_bulk').status_code == 404
 
     def test_limitted_post(self, client):
-        assert client.post('/api/v2/search/type').status_code == 400
-        assert client.post('/api/v2/search/type/').status_code == 400
-        assert client.post('/api/v2/search/type/id').status_code == 400
-        assert client.post('/api/v2/search/type/id/').status_code == 400
-        assert client.post('/api/v2/search/type/id/some/thing/else').status_code == 400
-        assert client.post('/api/v2/search/type/id/some/thing/else/').status_code == 400
-        assert client.post('/api/v2/search/type/id/_search').status_code == 400
-        assert client.post('/api/v2/search/type/id/_search/').status_code == 400
-        assert client.post('/api/v2/search/type/id/some/thing/else/_search').status_code == 400
-        assert client.post('/api/v2/search/type/id/some/thing/else/_search/').status_code == 400
-        assert client.post('/api/v2/search/type/id/some/thing/else/_count').status_code == 400
-        assert client.post('/api/v2/search/type/id/some/thing/else/_count/').status_code == 400
+        assert client.post('/api/v2/search/type').status_code == 403
+        assert client.post('/api/v2/search/type/').status_code == 403
+        assert client.post('/api/v2/search/type/id').status_code == 403
+        assert client.post('/api/v2/search/type/id/').status_code == 403
+        assert client.post('/api/v2/search/type/id/some/thing/else').status_code == 403
+        assert client.post('/api/v2/search/type/id/some/thing/else/').status_code == 403
+        assert client.post('/api/v2/search/type/id/_search').status_code == 403
+        assert client.post('/api/v2/search/type/id/_search/').status_code == 403
+        assert client.post('/api/v2/search/type/id/some/thing/else/_search').status_code == 403
+        assert client.post('/api/v2/search/type/id/some/thing/else/_search/').status_code == 403
+        assert client.post('/api/v2/search/type/id/some/thing/else/_count').status_code == 403
+        assert client.post('/api/v2/search/type/id/some/thing/else/_count/').status_code == 403
 
-    def test_scroll_not_implemented(self, client):
-        assert client.post('/api/v2/search/_search/scroll').status_code == 501
-        assert client.post('/api/v2/search/_search/?scroll=1m').status_code == 501
-        assert client.get('/api/v2/search/_search/scroll').status_code == 501
-        assert client.get('/api/v2/search/_search/?scroll=1m').status_code == 501
+    def test_scroll_forbidden(self, client):
+        assert client.post('/api/v2/search/_search/scroll').status_code == 403
+        assert client.post('/api/v2/search/_search/?scroll=1m').status_code == 403
+        assert client.get('/api/v2/search/_search/scroll').status_code == 403
+        assert client.get('/api/v2/search/_search/?scroll=1m').status_code == 403
 
     def test_post_search(self, client):
         urls = (
@@ -54,7 +54,7 @@ class TestElasticSearchProxy:
             '/api/v2/search/type/_count',
             '/api/v2/search/type/_count/',
             '/api/v2/search/type/_search',
-            '/api/v2/search/type/_search',
+            '/api/v2/search/type/_search/',
             '/api/v2/search/type/_suggest',
         )
         with mock.patch('api.views.elasticsearch.requests.post') as post:

--- a/tests/api/test_elasticsearch.py
+++ b/tests/api/test_elasticsearch.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import pytest
 
 
 class TestElasticSearchProxy:
@@ -61,3 +62,18 @@ class TestElasticSearchProxy:
             post.return_value = mock.Mock(status_code=200, json=lambda: {})
             for url in urls:
                 assert client.post(url, '{}', content_type='application/json').status_code == 200
+
+    @pytest.mark.parametrize('url', (
+        '/api/v2/search/_search',
+        '/api/v2/search/_search/',
+        '/api/v2/search/type/_count',
+        '/api/v2/search/type/_count/',
+        '/api/v2/search/type/_search',
+        '/api/v2/search/type/_search/',
+        '/api/v2/search/_mappings/',
+        '/api/v2/search/_mappings',
+        '/api/v2/search/_mappings/creativeworks',
+        '/api/v2/search/_mappings/creativeworks/',
+    ))
+    def test_get_search(self, client, url):
+        assert client.get(url).status_code == 200

--- a/tests/api/test_elasticsearch.py
+++ b/tests/api/test_elasticsearch.py
@@ -39,6 +39,12 @@ class TestElasticSearchProxy:
         assert client.post('/api/v2/search/type/id/some/thing/else/_count').status_code == 400
         assert client.post('/api/v2/search/type/id/some/thing/else/_count/').status_code == 400
 
+    def test_scroll_not_implemented(self, client):
+        assert client.post('/api/v2/search/_search/scroll').status_code == 501
+        assert client.post('/api/v2/search/_search/?scroll=1m').status_code == 501
+        assert client.get('/api/v2/search/_search/scroll').status_code == 501
+        assert client.get('/api/v2/search/_search/?scroll=1m').status_code == 501
+
     def test_post_search(self, client):
         urls = (
             '/api/v2/search/_search',

--- a/tests/bots/test_elastic.py
+++ b/tests/bots/test_elastic.py
@@ -1,36 +1,11 @@
 import pytest
-from urllib3.connection import ConnectionError
-
-from django.apps import apps
 
 from elasticsearch.exceptions import NotFoundError
-from elasticsearch.exceptions import ConnectionError as ElasticConnectionError
 
 from share.util import IDObfuscator
-
 from bots.elasticsearch import tasks
-from bots.elasticsearch.bot import ElasticSearchBot
 
 from tests import factories
-
-
-@pytest.fixture
-def elastic(settings):
-    settings.ELASTICSEARCH_TIMEOUT = 5
-    settings.ELASTICSEARCH_INDEX = 'test_' + settings.ELASTICSEARCH_INDEX
-
-    bot = ElasticSearchBot(apps.get_app_config('elasticsearch'), 1, es_setup=False)
-
-    try:
-        bot.es_client.indices.delete(index=settings.ELASTICSEARCH_INDEX, ignore=[400, 404])
-
-        bot.setup()
-    except (ConnectionError, ElasticConnectionError):
-        raise pytest.skip('Elasticsearch unavailable')
-
-    yield bot
-
-    bot.es_client.indices.delete(index=settings.ELASTICSEARCH_INDEX, ignore=[400, 404])
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Purpose
Handle elasticsearch scroll API requests.

## Changes
~~* Return `501` response if scroll requested
    * *also considered 400 and 403, thoughts?*~~
* Return `403` response if any improper search request is made 
* Add tests for es scroll API

## Side effects
None

## Ticket
https://openscience.atlassian.net/browse/SHARE-563