### PR TITLE
[Feature] Order OAI records by id, use cursor pagination

### DIFF
--- a/share/oaipmh/repository.py
+++ b/share/oaipmh/repository.py
@@ -105,7 +105,7 @@ class OAIRepository:
         if not queryset.exists():
             self.errors.append(oai_errors.NoResults())
             return [], None, None
-        # TODO is there a way to prefetch Sources/Relations/Identifiers just for this slice? https://code.djangoproject.com/ticket/26780
+        # TODO use django-include to prefetch relations/agents/identifiers/etc. in one query
         works = list(queryset[cursor:cursor + self.PAGE_SIZE + 1])
         if len(works) <= self.PAGE_SIZE:
             # Last page
@@ -115,7 +115,7 @@ class OAIRepository:
         return works, next_token, metadataRenderer
 
     def _record_queryset(self, kwargs, catch=True):
-        queryset = AbstractCreativeWork.objects.filter(is_deleted=False, same_as_id__isnull=True)
+        queryset = AbstractCreativeWork.objects.filter(is_deleted=False, same_as_id__isnull=True).order_by('-date_modified')
         if 'from' in kwargs:
             try:
                 from_ = dateutil.parser.parse(kwargs['from'])

--- a/share/oaipmh/repository.py
+++ b/share/oaipmh/repository.py
@@ -92,30 +92,30 @@ class OAIRepository:
     def _load_page(self, kwargs):
         if 'resumptionToken' in kwargs:
             try:
-                queryset, next_token, metadataRenderer, cursor = self._resume(kwargs['resumptionToken'])
+                queryset, kwargs = self._resume(kwargs['resumptionToken'])
+                metadataRenderer = self._get_metadata_renderer(kwargs['metadataPrefix'], catch=False)
             except (ValueError, KeyError):
                 self.errors.append(oai_errors.BadResumptionToken(kwargs['resumptionToken']))
         else:
             queryset = self._record_queryset(kwargs)
-            next_token = self._get_resumption_token(kwargs)
             metadataRenderer = self._get_metadata_renderer(kwargs['metadataPrefix'])
-            cursor = 0
         if self.errors:
             return [], None, None
         if not queryset.exists():
             self.errors.append(oai_errors.NoResults())
             return [], None, None
         # TODO use django-include to prefetch relations/agents/identifiers/etc. in one query
-        works = list(queryset[cursor:cursor + self.PAGE_SIZE + 1])
+        works = list(queryset[:self.PAGE_SIZE + 1])
         if len(works) <= self.PAGE_SIZE:
             # Last page
             next_token = None
         else:
             works = works[:self.PAGE_SIZE]
+            next_token = self._get_resumption_token(kwargs, works[-1].id)
         return works, next_token, metadataRenderer
 
     def _record_queryset(self, kwargs, catch=True):
-        queryset = AbstractCreativeWork.objects.filter(is_deleted=False, same_as_id__isnull=True).order_by('-date_modified')
+        queryset = AbstractCreativeWork.objects.filter(is_deleted=False, same_as_id__isnull=True).order_by('id')
         if 'from' in kwargs:
             try:
                 from_ = dateutil.parser.parse(kwargs['from'])
@@ -138,7 +138,7 @@ class OAIRepository:
         return queryset
 
     def _resume(self, token):
-        from_, until, set_spec, prefix, cursor = token.split('|')
+        from_, until, set_spec, prefix, last_id = token.split('|')
         kwargs = {}
         if from_:
             kwargs['from'] = from_
@@ -146,15 +146,11 @@ class OAIRepository:
             kwargs['until'] = until
         if set_spec:
             kwargs['set'] = set_spec
-        cursor = int(cursor)
-        queryset = self._record_queryset(kwargs, catch=False)
-        kwargs['cursor'] = cursor + self.PAGE_SIZE
         kwargs['metadataPrefix'] = prefix
-        next_token = self._get_resumption_token(kwargs)
-        metadataRenderer = self._get_metadata_renderer(prefix, catch=False)
-        return queryset, next_token, metadataRenderer, cursor
+        queryset = self._record_queryset(kwargs, catch=False).filter(id__gt=int(last_id))
+        return queryset, kwargs
 
-    def _get_resumption_token(self, kwargs):
+    def _get_resumption_token(self, kwargs, last_id):
         from_ = None
         until = None
         if 'from' in kwargs:
@@ -168,9 +164,8 @@ class OAIRepository:
             except ValueError:
                 self.errors.append(oai_errors.BadArgument('Invalid value for', 'until'))
         set_spec = kwargs.get('set', '')
-        cursor = kwargs.get('cursor', self.PAGE_SIZE)
-        return self._format_resumption_token(from_, until, set_spec, kwargs['metadataPrefix'], cursor)
+        return self._format_resumption_token(from_, until, set_spec, kwargs['metadataPrefix'], last_id)
 
-    def _format_resumption_token(self, from_, until, set_spec, prefix, cursor):
+    def _format_resumption_token(self, from_, until, set_spec, prefix, last_id):
         # TODO something more opaque, maybe
-        return '{}|{}|{}|{}|{}'.format(format_datetime(from_) if from_ else '', format_datetime(until) if until else '', set_spec, prefix, cursor)
+        return '{}|{}|{}|{}|{}'.format(format_datetime(from_) if from_ else '', format_datetime(until) if until else '', set_spec, prefix, last_id)

--- a/tests/share/test_oaipmh.py
+++ b/tests/share/test_oaipmh.py
@@ -155,17 +155,17 @@ class TestOAILists:
             assert errors[0].attrib.get('code') == 'noRecordsMatch'
             return
 
-        datestamps = []
         pages = 0
+        count = 0
         token = None
         while True:
             if token:
                 parsed = oai_request({'verb': verb, 'resumptionToken': token}, post)
             else:
                 parsed = oai_request({'verb': verb, 'metadataPrefix': 'oai_dc', **params}, post)
-            page = parsed.xpath('//ns0:header/ns0:datestamp', namespaces=NAMESPACES)
-            datestamps.extend(page)
+            page = parsed.xpath('//ns0:header/ns0:identifier', namespaces=NAMESPACES)
             pages += 1
+            count += len(page)
             token = parsed.xpath('//ns0:resumptionToken', namespaces=NAMESPACES)
             assert len(token) == 1
             token = token[0].text
@@ -175,7 +175,5 @@ class TestOAILists:
                 assert len(page) <= page_size
                 break
 
-        assert len(datestamps) == expected_count
+        assert count == expected_count
         assert pages == math.ceil(expected_count / page_size)
-        for i in range(len(datestamps) - 1):
-            assert datestamps[i].text >= datestamps[i + 1].text

--- a/tests/share/test_oaipmh.py
+++ b/tests/share/test_oaipmh.py
@@ -1,55 +1,85 @@
+import math
+import pendulum
 import pytest
+import random
 from lxml import etree
 
 from django.test.client import Client
 
+from share import models
+from share.oaipmh.util import format_datetime
 from share.util import IDObfuscator
+
+from tests.share.models import factories
+
+
+NAMESPACES = {
+    'dc': 'http://purl.org/dc/elements/1.1/',
+    'ns0': 'http://www.openarchives.org/OAI/2.0/',
+    'oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+}
+
+
+@pytest.fixture
+def oai_works():
+    return [factories.PreprintFactory() for i in range(17)]
+
+
+def oai_request(data, post, errors=False):
+    client = Client()
+    if post:
+        response = client.post('/oai-pmh/', data)
+    else:
+        response = client.get('/oai-pmh/', data)
+    assert response.status_code == 200
+    parsed = etree.fromstring(response.content, parser=etree.XMLParser(recover=True))
+    actual_errors = parsed.xpath('//ns0:error', namespaces=NAMESPACES)
+    if errors:
+        assert actual_errors
+        return actual_errors
+    assert not actual_errors
+    return parsed
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('post', [True, False])
-class TestOAIPMH:
-    namespaces = {
-        'dc': 'http://purl.org/dc/elements/1.1/',
-        'ns0': 'http://www.openarchives.org/OAI/2.0/',
-        'oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
-    }
+class TestOAIVerbs:
 
     def test_identify(self, post):
-        parsed = self._request({'verb': 'Identify'}, post)
-        assert parsed.xpath('//ns0:Identify/ns0:repositoryName', namespaces=self.namespaces)[0].text == 'SHARE'
+        parsed = oai_request({'verb': 'Identify'}, post)
+        assert parsed.xpath('//ns0:Identify/ns0:repositoryName', namespaces=NAMESPACES)[0].text == 'SHARE'
 
     def test_list_sets(self, post):
-        parsed = self._request({'verb': 'ListSets'}, post)
-        assert len(parsed.xpath('//ns0:ListSets/ns0:set', namespaces=self.namespaces)) > 100
+        parsed = oai_request({'verb': 'ListSets'}, post)
+        assert len(parsed.xpath('//ns0:ListSets/ns0:set', namespaces=NAMESPACES)) > 100
 
     def test_list_formats(self, post):
-        parsed = self._request({'verb': 'ListMetadataFormats'}, post)
-        prefixes = parsed.xpath('//ns0:ListMetadataFormats/ns0:metadataFormat/ns0:metadataPrefix', namespaces=self.namespaces)
+        parsed = oai_request({'verb': 'ListMetadataFormats'}, post)
+        prefixes = parsed.xpath('//ns0:ListMetadataFormats/ns0:metadataFormat/ns0:metadataPrefix', namespaces=NAMESPACES)
         assert len(prefixes) == 1
         assert prefixes[0].text == 'oai_dc'
 
     def test_list_identifiers(self, post, all_about_anteaters):
-        parsed = self._request({'verb': 'ListIdentifiers', 'metadataPrefix': 'oai_dc'}, post)
-        identifiers = parsed.xpath('//ns0:ListIdentifiers/ns0:header/ns0:identifier', namespaces=self.namespaces)
+        parsed = oai_request({'verb': 'ListIdentifiers', 'metadataPrefix': 'oai_dc'}, post)
+        identifiers = parsed.xpath('//ns0:ListIdentifiers/ns0:header/ns0:identifier', namespaces=NAMESPACES)
         assert len(identifiers) == 1
         assert identifiers[0].text == 'oai:share.osf.io:{}'.format(IDObfuscator.encode(all_about_anteaters))
 
     def test_list_records(self, post, all_about_anteaters):
-        parsed = self._request({'verb': 'ListRecords', 'metadataPrefix': 'oai_dc'}, post)
-        records = parsed.xpath('//ns0:ListRecords/ns0:record', namespaces=self.namespaces)
+        parsed = oai_request({'verb': 'ListRecords', 'metadataPrefix': 'oai_dc'}, post)
+        records = parsed.xpath('//ns0:ListRecords/ns0:record', namespaces=NAMESPACES)
         assert len(records) == 1
-        assert all_about_anteaters.title == records[0].xpath('ns0:metadata/oai_dc:dc/dc:title', namespaces=self.namespaces)[0].text
+        assert all_about_anteaters.title == records[0].xpath('ns0:metadata/oai_dc:dc/dc:title', namespaces=NAMESPACES)[0].text
         ant_id = 'oai:share.osf.io:{}'.format(IDObfuscator.encode(all_about_anteaters))
-        assert ant_id == records[0].xpath('ns0:header/ns0:identifier', namespaces=self.namespaces)[0].text
+        assert ant_id == records[0].xpath('ns0:header/ns0:identifier', namespaces=NAMESPACES)[0].text
 
     def test_get_record(self, post, all_about_anteaters):
         ant_id = 'oai:share.osf.io:{}'.format(IDObfuscator.encode(all_about_anteaters))
-        parsed = self._request({'verb': 'GetRecord', 'metadataPrefix': 'oai_dc', 'identifier': ant_id}, post)
-        records = parsed.xpath('//ns0:GetRecord/ns0:record', namespaces=self.namespaces)
+        parsed = oai_request({'verb': 'GetRecord', 'metadataPrefix': 'oai_dc', 'identifier': ant_id}, post)
+        records = parsed.xpath('//ns0:GetRecord/ns0:record', namespaces=NAMESPACES)
         assert len(records) == 1
-        assert all_about_anteaters.title == records[0].xpath('ns0:metadata/oai_dc:dc/dc:title', namespaces=self.namespaces)[0].text
-        assert ant_id == records[0].xpath('ns0:header/ns0:identifier', namespaces=self.namespaces)[0].text
+        assert all_about_anteaters.title == records[0].xpath('ns0:metadata/oai_dc:dc/dc:title', namespaces=NAMESPACES)[0].text
+        assert ant_id == records[0].xpath('ns0:header/ns0:identifier', namespaces=NAMESPACES)[0].text
 
     @pytest.mark.parametrize('verb, params, errors', [
         ('GetRecord', {}, ['badArgument']),
@@ -78,21 +108,74 @@ class TestOAIPMH:
     def test_oai_errors(self, verb, params, errors, post, all_about_anteaters):
         ant_id = IDObfuscator.encode(all_about_anteaters)
         data = {'verb': verb, **{k: v.format(id=ant_id) for k, v in params.items()}}
-        actual_errors = self._request(data, post, errors=True)
+        actual_errors = oai_request(data, post, errors=True)
         for error_code in errors:
             assert any(e.attrib.get('code') == error_code for e in actual_errors)
 
-    def _request(self, data, post, errors=False):
-        client = Client()
-        if post:
-            response = client.post('/oai-pmh/', data)
-        else:
-            response = client.get('/oai-pmh/', data)
-        assert response.status_code == 200
-        parsed = etree.fromstring(response.content, parser=etree.XMLParser(recover=True))
-        actual_errors = parsed.xpath('//ns0:error', namespaces=self.namespaces)
-        if errors:
-            assert actual_errors
-            return actual_errors
-        assert not actual_errors
-        return parsed
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('post', [True, False])
+@pytest.mark.parametrize('verb', ['ListRecords', 'ListIdentifiers'])
+@pytest.mark.parametrize('page_size', [5, 10, 100])
+class TestOAILists:
+
+    def test_full_list(self, oai_works, post, verb, page_size, monkeypatch):
+        monkeypatch.setattr('share.oaipmh.repository.OAIRepository.PAGE_SIZE', page_size)
+        self._assert_full_list(verb, {}, post, len(oai_works), page_size)
+
+    @pytest.mark.parametrize('from_date, to_date, expected_count', [
+        (pendulum.now().subtract(days=1), None, 17),
+        (None, pendulum.now().subtract(days=1), 0),
+        (pendulum.now().add(days=1), None, 0),
+        (None, pendulum.now().add(days=1), 17),
+        (pendulum.now().subtract(days=1), pendulum.now().add(days=1), 17),
+    ])
+    def test_filter_date(self, oai_works, post, verb, page_size, monkeypatch, from_date, to_date, expected_count):
+        monkeypatch.setattr('share.oaipmh.repository.OAIRepository.PAGE_SIZE', page_size)
+        params = {}
+        if from_date:
+            params['from'] = format_datetime(from_date)
+        if to_date:
+            params['until'] = format_datetime(to_date)
+        self._assert_full_list(verb, params, post, expected_count, page_size)
+
+    @pytest.mark.parametrize('expected_count', range(0, 17, 6))
+    def test_filter_set(self, oai_works, post, verb, page_size, monkeypatch, expected_count):
+        monkeypatch.setattr('share.oaipmh.repository.OAIRepository.PAGE_SIZE', page_size)
+        source = models.Source.objects.select_related('user').first()
+        for work in random.sample(oai_works, expected_count):
+            work.sources.add(source.user)
+
+        self._assert_full_list(verb, {'set': source.name}, post, expected_count, page_size)
+
+    def _assert_full_list(self, verb, params, post, expected_count, page_size):
+        if not expected_count:
+            errors = oai_request({'verb': verb, 'metadataPrefix': 'oai_dc', **params}, post, errors=True)
+            assert len(errors) == 1
+            assert errors[0].attrib.get('code') == 'noRecordsMatch'
+            return
+
+        datestamps = []
+        pages = 0
+        token = None
+        while True:
+            if token:
+                parsed = oai_request({'verb': verb, 'resumptionToken': token}, post)
+            else:
+                parsed = oai_request({'verb': verb, 'metadataPrefix': 'oai_dc', **params}, post)
+            page = parsed.xpath('//ns0:header/ns0:datestamp', namespaces=NAMESPACES)
+            datestamps.extend(page)
+            pages += 1
+            token = parsed.xpath('//ns0:resumptionToken', namespaces=NAMESPACES)
+            assert len(token) == 1
+            token = token[0].text
+            if token:
+                assert len(page) == page_size
+            else:
+                assert len(page) <= page_size
+                break
+
+        assert len(datestamps) == expected_count
+        assert pages == math.ceil(expected_count / page_size)
+        for i in range(len(datestamps) - 1):
+            assert datestamps[i].text >= datestamps[i + 1].text


### PR DESCRIPTION
Use an ordered queryset (by id ascending) for consistent pagination. Take advantage of that to put a cursor in the resumption token for faster page loads.

Also add tests for better coverage.