### PR TITLE
[SHARE-847][Task] Disable PubMed Central oai_dc config

### DIFF
--- a/share/sources/gov.pubmedcentral/source.yaml
+++ b/share/sources/gov.pubmedcentral/source.yaml
@@ -1,6 +1,6 @@
 configs:
 - base_url: https://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi
-  disabled: false
+  disabled: true
   earliest_date: null
   harvester: oai
   harvester_kwargs: {metadata_prefix: oai_dc, time_granularity: false}


### PR DESCRIPTION
*Already disabled on production*
## Purpose
Both source configs are enabled for PubMed Central which is unnecessary.