### PR TITLE
[SHARE-315][Feature] Catch KeyError for next link

### DIFF
--- a/share/harvesters/com_mendeley_data.py
+++ b/share/harvesters/com_mendeley_data.py
@@ -69,9 +69,9 @@ class MendeleyHarvester(BaseHarvester):
                             continue
                 yield (dataset['id'], dataset)
 
-            if 'Link' in resp.headers:
+            try:
                 resp = self.requests.get(resp.links['next']['url'], headers=headers)
-            else:
+            except KeyError:
                 break
 
     def get_contributor_profile(self, headers, contributor_uuid):


### PR DESCRIPTION
## Purpose
On the last page there wouldn't be a next link but there would be links. 

## Changes
Catch KeyError instead of checking for presence of links.