### PR TITLE
[SHARE-876][Feature] Allow source creation via API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -129,7 +129,7 @@ class ShareUserSerializer(ShareModelSerializer):
         model = models.ShareUser
         fields = (
             'username', 'first_name', 'last_name', 'email', 'date_joined', 'last_login',
-            'is_active', 'gravatar', 'locale', 'time_zone'
+            'is_active', 'gravatar', 'locale', 'time_zone', 'is_trusted'
         )
 
 

--- a/api/views/workflow.py
+++ b/api/views/workflow.py
@@ -79,20 +79,21 @@ class SourceViewSet(viewsets.ReadOnlyModelViewSet):
 
         user_serializer.is_valid(raise_exception=True)
 
-        user_instance = user_serializer.save()
-        source_instance = Source(
-            user_id=user_instance.id,
-            long_title=long_title,
-            home_page=request.data['home_page'] if 'home_page' in request.data else None,
-            name=label,
-        )
-        source_instance.icon.save(label, content=icon_file)
-        source_config_instance = SourceConfig.objects.create(source_id=source_instance.id, label=label)
+        with transaction.atomic():
+            user_instance = user_serializer.save()
+            source_instance = Source(
+                user_id=user_instance.id,
+                long_title=long_title,
+                home_page=request.data['home_page'] if 'home_page' in request.data else None,
+                name=label,
+            )
+            source_instance.icon.save(label, content=icon_file)
+            source_config_instance = SourceConfig.objects.create(source_id=source_instance.id, label=label)
 
         return Response(
             {
                 'id': source_instance.id,
-                'type': 'Sources',
+                'type': 'Source',
                 'attributes': {
                     'long_title': source_instance.long_title,
                     'name': source_instance.name,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ ipdb
 ipython
 pytest-benchmark==3.0.0
 pytest==3.0.6
+httpretty==0.8.14
 
 # pulling from github because master has django_assert_num_queries context mgr
 git+https://github.com/pytest-dev/pytest-django.git@master

--- a/project/settings.py
+++ b/project/settings.py
@@ -48,7 +48,6 @@ ALLOWED_HOSTS = [h for h in os.environ.get('ALLOWED_HOSTS', '').split(' ') if h]
 AUTH_USER_MODEL = 'share.ShareUser'
 
 JSON_API_FORMAT_KEYS = 'camelize'
-JSON_API_PLURALIZE_TYPES = True
 
 # Application definition
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -48,6 +48,7 @@ ALLOWED_HOSTS = [h for h in os.environ.get('ALLOWED_HOSTS', '').split(' ') if h]
 AUTH_USER_MODEL = 'share.ShareUser'
 
 JSON_API_FORMAT_KEYS = 'camelize'
+JSON_API_PLURALIZE_TYPES = True
 
 # Application definition
 

--- a/tests/api/test_readonly_endpoints.py
+++ b/tests/api/test_readonly_endpoints.py
@@ -1,8 +1,6 @@
 import json
 import pytest
 
-from share.models import Source
-
 
 def get_test_data(endpoint_type):
     test_data = {
@@ -35,50 +33,6 @@ class TestRawDataEndpoint:
             content_type='application/vnd.api+json',
             HTTP_AUTHORIZATION='Bearer ' + trusted_user.accesstoken_set.first().token,
         ).status_code == 405
-
-
-@pytest.mark.django_db
-class TestSourcesEndpoint:
-    endpoint = '/api/v2/sources/'
-
-    def test_count(self, client):
-        total = Source.objects.exclude(icon='').exclude(is_deleted=True).count()
-
-        resp = client.get(self.endpoint)
-
-        assert total > 0
-        assert resp.status_code == 200
-        assert resp.json()['meta']['pagination']['count'] == total
-
-    def test_post(self, client, trusted_user):
-        assert client.post(
-            self.endpoint,
-            json.dumps(get_test_data('Source')),
-            content_type='application/vnd.api+json',
-            HTTP_AUTHORIZATION='Bearer ' + trusted_user.accesstoken_set.first().token,
-        ).status_code == 405
-
-    def test_is_deleted(self, client):
-        total = Source.objects.exclude(icon='').exclude(is_deleted=True).count()
-
-        s = Source.objects.first()
-        s.is_deleted = True
-        s.save()
-
-        resp = client.get(self.endpoint)
-        assert resp.status_code == 200
-        assert resp.json()['meta']['pagination']['count'] == total - 1
-
-    def test_no_icon(self, client):
-        total = Source.objects.exclude(icon='').exclude(is_deleted=True).count()
-
-        s = Source.objects.first()
-        s.icon = None
-        s.save()
-
-        resp = client.get(self.endpoint)
-        assert resp.status_code == 200
-        assert resp.json()['meta']['pagination']['count'] == total - 1
 
 
 @pytest.mark.django_db

--- a/tests/api/test_sources_endpoint.py
+++ b/tests/api/test_sources_endpoint.py
@@ -12,7 +12,7 @@ INVALID_URL = 'invalidURL'
 def get_test_data(icon=PROPER_ICON_URL, home_page=None):
     test_data = {
         'data': {
-            'type': 'Source',
+            'type': 'Sources',
             'attributes': {
                 'long_title': 'Test User',
                 'icon': icon,
@@ -93,7 +93,7 @@ class TestSourcesPost:
         created_label = resp_attributes['long_title'].replace(' ', '_').lower()
         created_user = ShareUser.objects.get(pk=resp_related_share_user['id'])
 
-        assert resp.status_code == 202
+        assert resp.status_code == 201
         assert resp_attributes['long_title'] == test_data['data']['attributes']['long_title']
         assert resp_attributes['name'] == created_label
         assert resp_attributes['home_page'] is None
@@ -112,7 +112,7 @@ class TestSourcesPost:
         )
         resp_attributes = resp.data['attributes']
 
-        assert resp.status_code == 202
+        assert resp.status_code == 201
         assert resp_attributes['long_title'] == test_data['data']['attributes']['long_title']
         assert resp_attributes['home_page'] == test_data['data']['attributes']['home_page']
 

--- a/tests/api/test_sources_endpoint.py
+++ b/tests/api/test_sources_endpoint.py
@@ -1,5 +1,11 @@
 import json
 import pytest
+import time
+
+import httpretty
+
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 
 from share.models import Source, ShareUser
 
@@ -7,10 +13,22 @@ from share.models import Source, ShareUser
 PROPER_ICON_URL = 'https://staging-cdn.osf.io/preprints-assets/bitss/square_color_no_transparent.png'
 IMPROPER_ICON_URL = 'https://github.com/CenterForOpenScience/SHARE.git'
 INVALID_URL = 'invalidURL'
+TIMEOUT_URL = 'http://www.timeouturl.com'
 
 
-def get_test_data(icon=PROPER_ICON_URL, home_page=None):
-    test_data = {
+@pytest.fixture
+def source_add_user():
+    content_type = ContentType.objects.get_for_model(Source)
+    permission = Permission.objects.get(content_type=content_type, codename='add_source')
+
+    user = ShareUser(username='trusted_tester', is_trusted=True)
+    user.save()
+    user.user_permissions.add(permission)
+    return user
+
+
+def get_post_body(icon=PROPER_ICON_URL, home_page=None):
+    return {
         'data': {
             'type': 'Sources',
             'attributes': {
@@ -20,7 +38,6 @@ def get_test_data(icon=PROPER_ICON_URL, home_page=None):
             }
         }
     }
-    return test_data
 
 
 @pytest.mark.django_db
@@ -63,23 +80,53 @@ class TestSourcesGet:
 class TestSourcesPost:
     endpoint = '/api/v2/sources/'
 
+    def exceptionCallback(request, uri, headers):
+        time.sleep(6)
+        return (400, headers, uri)
+
+    httpretty.enable()
+    httpretty.HTTPretty.allow_net_connect = False
+
+    # smallest valid png, from https://github.com/mathiasbynens/small/blob/master/png-transparent.png
+    httpretty.register_uri(
+        httpretty.GET,
+        PROPER_ICON_URL,
+        body=b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82',
+        content_type='image/png'
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        IMPROPER_ICON_URL,
+        body=b'\n\n\n\n\n\n<!DOCTYPE html>\n<html lang="en">\n  <head>\n',
+        content_type='text/html'
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        INVALID_URL
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        TIMEOUT_URL,
+        body=exceptionCallback
+    )
+
     def test_unauthorized_post(self, client):
         assert client.post(
             self.endpoint,
-            json.dumps(get_test_data()),
+            json.dumps(get_post_body()),
             content_type='application/vnd.api+json'
         ).status_code == 401
 
     def test_improper_scope_post(self, client, share_user):
         assert client.post(
             self.endpoint,
-            json.dumps(get_test_data()),
+            json.dumps(get_post_body()),
             content_type='application/vnd.api+json',
             HTTP_AUTHORIZATION=share_user.authorization(),
         ).status_code == 403
 
     def test_successful_post_no_home_page(self, client, source_add_user):
-        test_data = get_test_data()
+        test_data = get_post_body()
         resp = client.post(
             self.endpoint,
             json.dumps(test_data),
@@ -103,7 +150,7 @@ class TestSourcesPost:
         assert resp_related_source_config['label'] == created_label
 
     def test_successful_post_home_page(self, client, source_add_user):
-        test_data = get_test_data(home_page='http://test.homepage.net')
+        test_data = get_post_body(home_page='http://test.homepage.net')
         resp = client.post(
             self.endpoint,
             json.dumps(test_data),
@@ -117,10 +164,9 @@ class TestSourcesPost:
         assert resp_attributes['home_page'] == test_data['data']['attributes']['home_page']
 
     def test_bad_image_url(self, client, source_add_user):
-        test_data = get_test_data(icon=IMPROPER_ICON_URL)
         resp = client.post(
             self.endpoint,
-            json.dumps(test_data),
+            json.dumps(get_post_body(icon=IMPROPER_ICON_URL)),
             content_type='application/vnd.api+json',
             HTTP_AUTHORIZATION=source_add_user.authorization(),
         )
@@ -129,13 +175,24 @@ class TestSourcesPost:
         assert resp.data[0]['detail'] == 'Could not download/process image. ["Invalid type. Expected one of (\'image/png\', \'image/jpeg\'). Received text/html"]'
 
     def test_invalid_url(self, client, source_add_user):
-        test_data = get_test_data(icon=INVALID_URL)
         resp = client.post(
             self.endpoint,
-            json.dumps(test_data),
+            json.dumps(get_post_body(icon=INVALID_URL)),
             content_type='application/vnd.api+json',
             HTTP_AUTHORIZATION=source_add_user.authorization(),
         )
 
         assert resp.status_code == 400
         assert resp.data[0]['detail'] == 'Could not download/process image. Invalid URL \'invalidURL\': No schema supplied. Perhaps you meant http://invalidURL?'
+
+    def test_timeout_url(self, client, source_add_user):
+        resp = client.post(
+            self.endpoint,
+            json.dumps(get_post_body(icon=TIMEOUT_URL)),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION=source_add_user.authorization(),
+        )
+
+        assert resp.data[0]['detail'].startswith('Could not download/process image. HTTPConnectionPool(host=\'www.timeouturl.com\', port=80): ')
+
+    httpretty.disable()

--- a/tests/api/test_sources_endpoint.py
+++ b/tests/api/test_sources_endpoint.py
@@ -1,0 +1,141 @@
+import json
+import pytest
+
+from share.models import Source, ShareUser
+
+
+PROPER_ICON_URL = 'https://staging-cdn.osf.io/preprints-assets/bitss/square_color_no_transparent.png'
+IMPROPER_ICON_URL = 'https://github.com/CenterForOpenScience/SHARE.git'
+INVALID_URL = 'invalidURL'
+
+
+def get_test_data(icon=PROPER_ICON_URL, home_page=None):
+    test_data = {
+        'data': {
+            'type': 'Source',
+            'attributes': {
+                'long_title': 'Test User',
+                'icon': icon,
+                'home_page': home_page
+            }
+        }
+    }
+    return test_data
+
+
+@pytest.mark.django_db
+class TestSourcesGet:
+    endpoint = '/api/v2/sources/'
+
+    def test_count(self, client):
+        total = Source.objects.exclude(icon='').exclude(is_deleted=True).count()
+
+        resp = client.get(self.endpoint)
+
+        assert total > 0
+        assert resp.status_code == 200
+        assert resp.json()['meta']['pagination']['count'] == total
+
+    def test_is_deleted(self, client):
+        total = Source.objects.exclude(icon='').exclude(is_deleted=True).count()
+
+        s = Source.objects.first()
+        s.is_deleted = True
+        s.save()
+
+        resp = client.get(self.endpoint)
+        assert resp.status_code == 200
+        assert resp.json()['meta']['pagination']['count'] == total - 1
+
+    def test_no_icon(self, client):
+        total = Source.objects.exclude(icon='').exclude(is_deleted=True).count()
+
+        s = Source.objects.first()
+        s.icon = None
+        s.save()
+
+        resp = client.get(self.endpoint)
+        assert resp.status_code == 200
+        assert resp.json()['meta']['pagination']['count'] == total - 1
+
+
+@pytest.mark.django_db
+class TestSourcesPost:
+    endpoint = '/api/v2/sources/'
+
+    def test_unauthorized_post(self, client):
+        assert client.post(
+            self.endpoint,
+            json.dumps(get_test_data()),
+            content_type='application/vnd.api+json'
+        ).status_code == 401
+
+    def test_improper_scope_post(self, client, share_user):
+        assert client.post(
+            self.endpoint,
+            json.dumps(get_test_data()),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION=share_user.authorization(),
+        ).status_code == 403
+
+    def test_successful_post_no_home_page(self, client, source_add_user):
+        test_data = get_test_data()
+        resp = client.post(
+            self.endpoint,
+            json.dumps(test_data),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION=source_add_user.authorization(),
+        )
+        resp_attributes = resp.data['attributes']
+        resp_related_share_user = resp.data['relationships']['share_user']['data']
+        resp_related_source_config = resp.data['relationships']['source_config']['data']['attributes']
+
+        created_label = resp_attributes['long_title'].replace(' ', '_').lower()
+        created_user = ShareUser.objects.get(pk=resp_related_share_user['id'])
+
+        assert resp.status_code == 202
+        assert resp_attributes['long_title'] == test_data['data']['attributes']['long_title']
+        assert resp_attributes['name'] == created_label
+        assert resp_attributes['home_page'] is None
+        assert resp_related_share_user['attributes']['username'] == created_label
+        assert resp_related_share_user['attributes']['authorization_token'] == created_user.accesstoken_set.first().token
+        assert created_user.is_trusted is True
+        assert resp_related_source_config['label'] == created_label
+
+    def test_successful_post_home_page(self, client, source_add_user):
+        test_data = get_test_data(home_page='http://test.homepage.net')
+        resp = client.post(
+            self.endpoint,
+            json.dumps(test_data),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION=source_add_user.authorization(),
+        )
+        resp_attributes = resp.data['attributes']
+
+        assert resp.status_code == 202
+        assert resp_attributes['long_title'] == test_data['data']['attributes']['long_title']
+        assert resp_attributes['home_page'] == test_data['data']['attributes']['home_page']
+
+    def test_bad_image_url(self, client, source_add_user):
+        test_data = get_test_data(icon=IMPROPER_ICON_URL)
+        resp = client.post(
+            self.endpoint,
+            json.dumps(test_data),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION=source_add_user.authorization(),
+        )
+
+        assert resp.status_code == 400
+        assert resp.data[0]['detail'] == 'Could not download/process image. ["Invalid type. Expected one of (\'image/png\', \'image/jpeg\'). Received text/html"]'
+
+    def test_invalid_url(self, client, source_add_user):
+        test_data = get_test_data(icon=INVALID_URL)
+        resp = client.post(
+            self.endpoint,
+            json.dumps(test_data),
+            content_type='application/vnd.api+json',
+            HTTP_AUTHORIZATION=source_add_user.authorization(),
+        )
+
+        assert resp.status_code == 400
+        assert resp.data[0]['detail'] == 'Could not download/process image. Invalid URL \'invalidURL\': No schema supplied. Perhaps you meant http://invalidURL?'

--- a/tests/api/test_sources_endpoint.py
+++ b/tests/api/test_sources_endpoint.py
@@ -30,7 +30,7 @@ def source_add_user():
 def get_post_body(icon=PROPER_ICON_URL, home_page=None):
     return {
         'data': {
-            'type': 'Sources',
+            'type': 'Source',
             'attributes': {
                 'long_title': 'Test User',
                 'icon': icon,

--- a/tests/api/test_sources_endpoint.py
+++ b/tests/api/test_sources_endpoint.py
@@ -8,12 +8,18 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 
 from share.models import Source, ShareUser
+from share.util import IDObfuscator
 
 
 PROPER_ICON_URL = 'https://staging-cdn.osf.io/preprints-assets/bitss/square_color_no_transparent.png'
 IMPROPER_ICON_URL = 'https://github.com/CenterForOpenScience/SHARE.git'
 INVALID_URL = 'invalidURL'
 TIMEOUT_URL = 'http://www.timeouturl.com'
+
+
+def exceptionCallback(request, uri, headers):
+        time.sleep(6)
+        return (400, headers, uri)
 
 
 @pytest.fixture
@@ -25,6 +31,35 @@ def source_add_user():
     user.save()
     user.user_permissions.add(permission)
     return user
+
+
+@pytest.fixture
+def mock_icon_urls():
+    httpretty.enable()
+    httpretty.HTTPretty.allow_net_connect = False
+
+    # smallest valid png, from https://github.com/mathiasbynens/small/blob/master/png-transparent.png
+    httpretty.register_uri(
+        httpretty.GET,
+        PROPER_ICON_URL,
+        body=b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82',
+        content_type='image/png'
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        IMPROPER_ICON_URL,
+        body=b'\n\n\n\n\n\n<!DOCTYPE html>\n<html lang="en">\n  <head>\n',
+        content_type='text/html'
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        INVALID_URL
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        TIMEOUT_URL,
+        body=exceptionCallback
+    )
 
 
 def get_post_body(icon=PROPER_ICON_URL, home_page=None):
@@ -80,36 +115,6 @@ class TestSourcesGet:
 class TestSourcesPost:
     endpoint = '/api/v2/sources/'
 
-    def exceptionCallback(request, uri, headers):
-        time.sleep(6)
-        return (400, headers, uri)
-
-    httpretty.enable()
-    httpretty.HTTPretty.allow_net_connect = False
-
-    # smallest valid png, from https://github.com/mathiasbynens/small/blob/master/png-transparent.png
-    httpretty.register_uri(
-        httpretty.GET,
-        PROPER_ICON_URL,
-        body=b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82',
-        content_type='image/png'
-    )
-    httpretty.register_uri(
-        httpretty.GET,
-        IMPROPER_ICON_URL,
-        body=b'\n\n\n\n\n\n<!DOCTYPE html>\n<html lang="en">\n  <head>\n',
-        content_type='text/html'
-    )
-    httpretty.register_uri(
-        httpretty.GET,
-        INVALID_URL
-    )
-    httpretty.register_uri(
-        httpretty.GET,
-        TIMEOUT_URL,
-        body=exceptionCallback
-    )
-
     def test_unauthorized_post(self, client):
         assert client.post(
             self.endpoint,
@@ -117,7 +122,7 @@ class TestSourcesPost:
             content_type='application/vnd.api+json'
         ).status_code == 401
 
-    def test_improper_scope_post(self, client, share_user):
+    def test_improper_scope_post(self, client, share_user, mock_icon_urls):
         assert client.post(
             self.endpoint,
             json.dumps(get_post_body()),
@@ -125,7 +130,7 @@ class TestSourcesPost:
             HTTP_AUTHORIZATION=share_user.authorization(),
         ).status_code == 403
 
-    def test_successful_post_no_home_page(self, client, source_add_user):
+    def test_successful_post_no_home_page(self, client, source_add_user, mock_icon_urls):
         test_data = get_post_body()
         resp = client.post(
             self.endpoint,
@@ -138,7 +143,7 @@ class TestSourcesPost:
         resp_related_source_config = resp.data['relationships']['source_config']['data']['attributes']
 
         created_label = resp_attributes['long_title'].replace(' ', '_').lower()
-        created_user = ShareUser.objects.get(pk=resp_related_share_user['id'])
+        created_user = ShareUser.objects.get(pk=IDObfuscator.decode_id(resp_related_share_user['id']))
 
         assert resp.status_code == 201
         assert resp_attributes['long_title'] == test_data['data']['attributes']['long_title']
@@ -149,7 +154,7 @@ class TestSourcesPost:
         assert created_user.is_trusted is True
         assert resp_related_source_config['label'] == created_label
 
-    def test_successful_post_home_page(self, client, source_add_user):
+    def test_successful_post_home_page(self, client, source_add_user, mock_icon_urls):
         test_data = get_post_body(home_page='http://test.homepage.net')
         resp = client.post(
             self.endpoint,
@@ -163,7 +168,7 @@ class TestSourcesPost:
         assert resp_attributes['long_title'] == test_data['data']['attributes']['long_title']
         assert resp_attributes['home_page'] == test_data['data']['attributes']['home_page']
 
-    def test_bad_image_url(self, client, source_add_user):
+    def test_bad_image_url(self, client, source_add_user, mock_icon_urls):
         resp = client.post(
             self.endpoint,
             json.dumps(get_post_body(icon=IMPROPER_ICON_URL)),
@@ -172,9 +177,9 @@ class TestSourcesPost:
         )
 
         assert resp.status_code == 400
-        assert resp.data[0]['detail'] == 'Could not download/process image. ["Invalid type. Expected one of (\'image/png\', \'image/jpeg\'). Received text/html"]'
+        assert resp.data[0]['detail'] == 'Could not download/process image.'
 
-    def test_invalid_url(self, client, source_add_user):
+    def test_invalid_url(self, client, source_add_user, mock_icon_urls):
         resp = client.post(
             self.endpoint,
             json.dumps(get_post_body(icon=INVALID_URL)),
@@ -183,9 +188,9 @@ class TestSourcesPost:
         )
 
         assert resp.status_code == 400
-        assert resp.data[0]['detail'] == 'Could not download/process image. Invalid URL \'invalidURL\': No schema supplied. Perhaps you meant http://invalidURL?'
+        assert resp.data[0]['detail'] == 'Could not download/process image.'
 
-    def test_timeout_url(self, client, source_add_user):
+    def test_timeout_url(self, client, source_add_user, mock_icon_urls):
         resp = client.post(
             self.endpoint,
             json.dumps(get_post_body(icon=TIMEOUT_URL)),
@@ -193,6 +198,4 @@ class TestSourcesPost:
             HTTP_AUTHORIZATION=source_add_user.authorization(),
         )
 
-        assert resp.data[0]['detail'].startswith('Could not download/process image. HTTPConnectionPool(host=\'www.timeouturl.com\', port=80): ')
-
-    httpretty.disable()
+        assert resp.data[0]['detail'] == 'Could not download/process image.'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ from django.db import connections
 from django.db import transaction
 from django.conf import settings
 from django.db.models.signals import post_save
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
 from oauth2_provider.models import AccessToken, Application
 from urllib3.connection import ConnectionError
 from elasticsearch.exceptions import ConnectionError as ElasticConnectionError
@@ -64,6 +67,17 @@ def apply_test_settings(settings):
 def trusted_user():
     user = ShareUser(username='trusted_tester', is_trusted=True)
     user.save()
+    return user
+
+
+@pytest.fixture
+def source_add_user():
+    content_type = ContentType.objects.get_for_model(Source)
+    permission = Permission.objects.get(content_type=content_type, codename='add_source')
+
+    user = ShareUser(username='trusted_tester', is_trusted=True)
+    user.save()
+    user.user_permissions.add(permission)
     return user
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,6 @@ from django.db import connections
 from django.db import transaction
 from django.conf import settings
 from django.db.models.signals import post_save
-from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 
 from oauth2_provider.models import AccessToken, Application
 from urllib3.connection import ConnectionError
@@ -67,17 +65,6 @@ def apply_test_settings(settings):
 def trusted_user():
     user = ShareUser(username='trusted_tester', is_trusted=True)
     user.save()
-    return user
-
-
-@pytest.fixture
-def source_add_user():
-    content_type = ContentType.objects.get_for_model(Source)
-    permission = Permission.objects.get(content_type=content_type, codename='add_source')
-
-    user = ShareUser(username='trusted_tester', is_trusted=True)
-    user.save()
-    user.user_permissions.add(permission)
     return user
 
 


### PR DESCRIPTION
## Questions for reviewer(s)
1. Should update be supported for icons only? The way the system currently works, updating the `long_title` would not be desirable. Is allowing updates to just the icon worth implementing?
2. Is using `long_title` submission to create the other username/label/name the best solution? 

## Purpose 
Allow creation of a source with the API.
See, https://openscience.atlassian.net/browse/SHARE-876

## Changes
* Add `create()` method to `sources/` endpoint which creates ShareUser, Source, and SourceConfig.
* Add `is_trusted` to `ShareUserSerializer` so that trusted users can be created.
* The OSF user will need to have the `add_source` permission.

### Request Content
```json
{
    "data": {
        "type": "Source",
        "attributes": {
            "homePage": "http://super.test.edu",  (optional)
            "longTitle": "Super Test",
            "icon": "<url_for_icon>"
        }
    }
}
```

### Response
```json
{
    "data": {
        "attributes": {
            "home_page": "http://super.test.edu",
            "name": "super_test",
            "long_title": "Super Test"
        },
        "id": "XXXXX-XXX-XXX",
        "relationships": {
            "share_user": {
                "data": {
                    "attributes": {
                        "username": "super_test",
                        "authorization_token": "N2RDMXU397HFIAA19CVZIOM1Q50BUJZQ85WCAFU49WIR46TIYQJ9VZKSLT6AKBXP"
                    },
                    "id": "XXXXX-XXX-XXX",
                    "type": "ShareUser"
                }
            },
            "source_config": {
                "data": {
                    "attributes": {
                        "label": "super_test"
                    },
                    "id": "XXXXX-XXX-XXX",
                    "type": "SourceConfig"
                }
            }
        },
        "type": "Sources"
    }
}
```

### Errors
```json
{
    "errors": [
        {
            "detail": "Could not download/process image. [\"Invalid type. Expected one of ('image/png', 'image/jpeg'). Received text/html\"]",
            "status": "400",
            "source": {
                "pointer": "/data"
            }
        }
    ]
}
```