### PR TITLE
[Fix] Backward-compatible force_text

### DIFF
--- a/share/transform/chain/utils.py
+++ b/share/transform/chain/utils.py
@@ -46,7 +46,7 @@ def format_address(address1='', address2='', city='', state_or_province='', post
     return address1
 
 
-def force_text(data, list_sep=None):
+def force_text(data, list_sep=None, first_str=False):
     if isinstance(data, dict):
         return data.get('#text', '')
 
@@ -67,6 +67,9 @@ def force_text(data, list_sep=None):
                 text_list.append(datum)
             else:
                 raise Exception(datum)
+
+            if first_str and text_list:
+                return text_list[0]
         if list_sep is not None:
             return list_sep.join(text_list)
         return text_list

--- a/share/transform/chain/utils.py
+++ b/share/transform/chain/utils.py
@@ -46,7 +46,7 @@ def format_address(address1='', address2='', city='', state_or_province='', post
     return address1
 
 
-def force_text(data):
+def force_text(data, list_sep=None):
     if isinstance(data, dict):
         return data.get('#text', '')
 
@@ -67,6 +67,8 @@ def force_text(data):
                 text_list.append(datum)
             else:
                 raise Exception(datum)
+        if list_sep is not None:
+            return list_sep.join(text_list)
         return text_list
 
     if data is None:

--- a/share/transformers/mods.py
+++ b/share/transformers/mods.py
@@ -204,7 +204,7 @@ class MODSCreativeWork(Parser):
 
     # Abstracts have the optional attribute "shareable". Don't bother checking for it, because
     # abstracts that are not shareable should not have been shared with SHARE.
-    description = tools.Join(tools.RunPython(force_text, tools.Try(ctx['mods:abstract'])))
+    description = tools.Join(tools.RunPython(force_text, tools.Try(ctx['mods:abstract']), '\n'))
 
     identifiers = tools.Map(
         tools.Delegate(MODSWorkIdentifier),
@@ -258,7 +258,7 @@ class MODSCreativeWork(Parser):
         ),
     )
 
-    rights = tools.RunPython(force_text, tools.Try(ctx['mods:accessCondition']))
+    rights = tools.RunPython(force_text, tools.Try(ctx['mods:accessCondition']), '\n')
 
     language = tools.ParseLanguage(
         tools.Try(ctx['mods:language']['mods:languageTerm']),
@@ -394,7 +394,7 @@ class MODSCreativeWork(Parser):
     # Map titleInfos to a string: https://www.loc.gov/standards/mods/userguide/titleinfo.html#mappings
     def join_title_info(self, obj):
         def get_part(title_info, part_name, delimiter=''):
-            part = force_text(title_info.get(part_name, '')).strip()
+            part = force_text(title_info.get(part_name, ''), ' ').strip()
             return delimiter + part if part else ''
 
         title_infos = get_list(obj, 'mods:titleInfo')

--- a/share/transformers/org_datacite.py
+++ b/share/transformers/org_datacite.py
@@ -468,7 +468,8 @@ class CreativeWork(Parser):
 
     title = tools.RunPython(
         force_text,
-        tools.Try(ctx.record.metadata['oai_datacite'].payload.resource.titles.title)
+        tools.Try(ctx.record.metadata['oai_datacite'].payload.resource.titles.title),
+        first_str=True
     )
 
     description = tools.Try(

--- a/tests/share/util/test_force_text.py
+++ b/tests/share/util/test_force_text.py
@@ -15,3 +15,18 @@ from share.transform.chain.utils import force_text
 ])
 def test_force_text(input_text, output_text):
     assert force_text(input_text) == output_text
+
+
+@pytest.mark.parametrize('input_text, list_sep, output_text', [
+    (['architecture', 'art', 'mechanical'], None, ['architecture', 'art', 'mechanical']),
+    (['architecture', 'art', 'mechanical'], '\n', 'architecture\nart\nmechanical'),
+    (['architecture', 'art', 'mechanical'], ' word ', 'architecture word art word mechanical'),
+    (['architecture', {'#text': 'art'}, 'mechanical'], '\n', 'architecture\nart\nmechanical'),
+    (['architecture', {'#text': 'art'}, None], ' f', 'architecture fart'),
+    ([None, {'#text': 'art'}, None], '|', 'art'),
+    ({'#text': 'art'}, ' word ', 'art'),
+    ('mechanical', 'foo', 'mechanical'),
+    (None, '\n', ''),
+])
+def test_force_text_joined(input_text, list_sep, output_text):
+    assert force_text(input_text, list_sep) == output_text


### PR DESCRIPTION
Update `force_text` to optionally join lists of strings with a given separator. 