### PR TITLE
[RANDOM][Feature] Allow long_title query param on sources endpoint

### DIFF
--- a/api/views/workflow.py
+++ b/api/views/workflow.py
@@ -6,6 +6,7 @@ import requests
 from django.db import transaction
 from django.utils import timezone
 from django.core.files.base import ContentFile
+from django_filters.rest_framework import DjangoFilterBackend
 
 from rest_framework import viewsets, views, status
 from rest_framework.response import Response
@@ -48,13 +49,12 @@ class SourceViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = ('long_title', )
     serializer_class = SourceSerializer
     permission_classes = [DjangoModelPermissionsOrAnonReadOnly, ]
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('long_title',)
 
-    queryset = Source.objects.none()  # Required for DjangoModelPermissions
+    queryset = Source.objects.exclude(icon='').exclude(is_deleted=True)  # Required for DjangoModelPermissions
 
     VALID_IMAGE_TYPES = ('image/png', 'image/jpeg')
-
-    def get_queryset(self):
-        return Source.objects.exclude(icon='').exclude(is_deleted=True)
 
     def create(self, request, *args, **kwargs):
         try:

--- a/share/models/ingest.py
+++ b/share/models/ingest.py
@@ -69,6 +69,7 @@ class Source(models.Model):
     name = models.TextField(unique=True)
     long_title = models.TextField(unique=True)
     home_page = models.URLField(null=True)
+    # Sources without an icon are excluded from the API
     icon = models.ImageField(upload_to=icon_name, storage=SourceIconStorage(), blank=True)
     is_deleted = models.BooleanField(default=False)
 

--- a/tests/api/test_sources_endpoint.py
+++ b/tests/api/test_sources_endpoint.py
@@ -3,6 +3,7 @@ import pytest
 import time
 
 import httpretty
+from furl import furl
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -109,6 +110,16 @@ class TestSourcesGet:
         resp = client.get(self.endpoint)
         assert resp.status_code == 200
         assert resp.json()['meta']['pagination']['count'] == total - 1
+
+    def test_long_titles_param(self, client):
+        source_long_title = Source.objects.first().long_title
+
+        url = furl(self.endpoint).set({'long_title': source_long_title})
+        resp = client.get(url.url)
+
+        assert resp.status_code == 200
+        assert resp.json()['meta']['pagination']['count'] == 1
+        assert resp.json()['data'][0]['attributes']['longTitle'] == source_long_title
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Purpose
Misc feature that could be useful if we ever do a source detail page.

~~The sources page shows more sources than the source donut on the discover page. Since we can't tell if a source has data in elastic search using the API, the sources page will need to be based on an elastic aggregation. Favicons aren't in the elastic results. To reduce the number of requests, the sources endpoint accepts a query parameter to specify which sources to return. The frontend can do an elastic search aggregation, get those source names, and then make a request for only those sources.~~

## Changes
Allow `long_title` query parameter for the sources endpoint. 

## Side-effects
None