### PR TITLE
[SHARE-828][Feature]Update deprecated regex to support Python 3.6

### DIFF
--- a/share/transform/chain/links.py
+++ b/share/transform/chain/links.py
@@ -672,7 +672,7 @@ class ISNILink(AbstractIRILink):
         (None, 150000007),
         (350000001, None),
     )
-    ISNI_RE = re.compile(r'^(?:https?://)?[^\B=/\d]*/?(\d{4})-?(\d{4})-?(\d{4})-?(\d{3}(?:\d|x))\b', re.I)
+    ISNI_RE = re.compile(r'^(?:https?://)?[^=/\d]*/?(\d{4})-?(\d{4})-?(\d{4})-?(\d{3}(?:\d|x))\b', re.I)
 
     @classmethod
     def hint(cls, obj):
@@ -751,7 +751,7 @@ class DOILink(AbstractIRILink):
 
     DOI_SCHEME = 'http'
     DOI_DOMAIN = 'dx.doi.org'
-    DOI_RE = re.compile(r'^(?:https?://)?[^\B=/]*/?(10\.\d{4,}(?:\.\d+)*(?:/|%2F)\S+(?:(?![\"&\'<>])))\b', re.I)
+    DOI_RE = re.compile(r'^(?:https?://)?[^=/]*/?(10\.\d{4,}(?:\.\d+)*(?:/|%2F)\S+(?:(?![\"&\'<>])))\b', re.I)
 
     @classmethod
     def hint(cls, obj):


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/SHARE-828

## Problem
Some of our regexes use a deprecated syntax that breaks in python 3.6
Deprecations can be found by running python -Wa manage.py
We need to upgrade to python 3.6

## Solution:

- Remove \B from regex for both ISNI and DOI.
- Run **test_isni_link** and **test_doi_link** under tests/share/normalize/test_links and make sure all tests pass.
