### PR TITLE
[Fix] Fix 500 error at /userinfo/ endpoint

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -20,6 +20,8 @@ class ShareUserViewSet(viewsets.ReadOnlyModelViewSet):
 
 # TODO Remove this when refactoring users endpoints (SHARE-586)
 class ShareUserView(views.APIView):
+    resource_name = 'ShareUser'
+
     def get(self, request, *args, **kwargs):
         ser = ShareUserWithTokenSerializer(request.user)
         return Response(ser.data)

--- a/share/util/__init__.py
+++ b/share/util/__init__.py
@@ -37,7 +37,7 @@ class IDObfuscator:
 
     @classmethod
     def encode(cls, instance):
-        return cls.encode_id(instance.id, type(instance))
+        return cls.encode_id(instance.id, instance._meta.model)
 
     @classmethod
     def encode_id(cls, pk, model):


### PR DESCRIPTION
`IDObfuscator.encode` used `type()` to get the model of an instance, which broke on the `SimpleLazyObject` wrapper Django uses for users. Instead, use `instance._meta`, which is proxied to the wrapped object, and should work equivalently for all models.