### PR TITLE
[SHARE-1000][Feature] Add lineage to works in the search index

### DIFF
--- a/bots/elasticsearch/bot.py
+++ b/bots/elasticsearch/bot.py
@@ -108,7 +108,7 @@ class ElasticSearchBot:
 
     MAPPINGS = {
         'creativeworks': {
-            'dynamic': False,
+            'dynamic': 'strict',
             'properties': {
                 'affiliations': {'type': 'text', 'fields': EXACT_FIELD},
                 'contributors': {'type': 'text', 'fields': EXACT_FIELD},

--- a/share/search/fetchers.py
+++ b/share/search/fetchers.py
@@ -115,237 +115,265 @@ class CreativeWorkFetcher(Fetcher):
     ORDER BY pks.ord;
     '''
 
-    QUERY = '''
-    all_tags AS (
-        SELECT
-            creative_work_id AS creativework_id,
-            array_agg(share_tag.name) AS tags
-        FROM share_tag
-            JOIN share_throughtags ON share_tag.id = share_throughtags.tag_id
-        WHERE share_throughtags.creative_work_id IN (SELECT id FROM pks)
-        GROUP BY creative_work_id
-    ),
-    all_sources AS (
-        SELECT
-             abstractcreativework_id AS creativework_id,
-             array_agg(DISTINCT share_source.long_title) AS sources
-        FROM share_creativework_sources
-            JOIN share_shareuser ON share_creativework_sources.shareuser_id = share_shareuser.id
-            JOIN share_source ON share_shareuser.id = share_source.user_id
-        WHERE share_creativework_sources.abstractcreativework_id IN (SELECT id FROM pks)
-        AND NOT share_source.is_deleted
-        GROUP BY abstractcreativework_id
-    ),
-    all_related_agents AS (
-        SELECT
-            agent_relation.creative_work_id AS creativework_id,
-            json_agg(json_strip_nulls(json_build_object(
-                'id', agent.id
-                , 'type', agent.type
-                , 'name', agent.name
-                , 'given_name', agent.given_name
-                , 'family_name', agent.family_name
-                , 'additional_name', agent.additional_name
-                , 'suffix', agent.suffix
-                , 'identifiers', COALESCE(identifiers, '{}')
-                , 'relation_type', agent_relation.type
-                , 'order_cited', agent_relation.order_cited
-                , 'cited_as', agent_relation.cited_as
-                , 'affiliations', COALESCE(affiliations, '[]'::json)
-                , 'awards', COALESCE(awards, '[]'::json)
-            ))) AS related_agents
-        FROM share_agentworkrelation AS agent_relation
-            JOIN share_agent AS agent ON agent_relation.agent_id = agent.id
-
-        LEFT JOIN LATERAL (
+    QUERY = (
+        # Gather all the tags in one query, for use below
+        '''
+        all_tags AS (
             SELECT
-                array_agg(identifier.uri) AS identifiers
-            FROM share_agentidentifier AS identifier
-            WHERE identifier.agent_id = agent.id
-            AND identifier.scheme != 'mailto'
-            LIMIT 51
-        ) AS identifiers ON TRUE
+                creative_work_id AS creativework_id,
+                array_agg(share_tag.name) AS tags
+            FROM share_tag
+                JOIN share_throughtags ON share_tag.id = share_throughtags.tag_id
+            WHERE share_throughtags.creative_work_id IN (SELECT id FROM pks)
+            GROUP BY creative_work_id
+        ),
+        '''
 
-        LEFT JOIN LATERAL (
-            SELECT json_agg(json_strip_nulls(json_build_object(
-                'id', affiliated_agent.id
-                , 'type', affiliated_agent.type
-                , 'name', affiliated_agent.name
-                , 'affiliation_type', affiliation.type
-            ))) AS affiliations
-            FROM share_agentrelation AS affiliation
-                JOIN share_agent AS affiliated_agent ON affiliation.related_id = affiliated_agent.id
-            WHERE affiliation.subject_id = agent.id AND affiliated_agent.type != 'share.person'
-        ) AS affiliations ON (agent.type = 'share.person')
+        # Gather all the sources in one query, for use below
+        '''
+        all_sources AS (
+            SELECT
+                 abstractcreativework_id AS creativework_id,
+                 array_agg(DISTINCT share_source.long_title) AS sources
+            FROM share_creativework_sources
+                JOIN share_shareuser ON share_creativework_sources.shareuser_id = share_shareuser.id
+                JOIN share_source ON share_shareuser.id = share_source.user_id
+            WHERE share_creativework_sources.abstractcreativework_id IN (SELECT id FROM pks)
+            AND NOT share_source.is_deleted
+            GROUP BY abstractcreativework_id
+        ),
+        '''
 
-        LEFT JOIN LATERAL (
-            SELECT json_agg(json_strip_nulls(json_build_object(
-                'id', award.id
-                , 'type', 'share.award'
-                , 'date', award.date
-                , 'name', award.name
-                , 'description', award.description
-                , 'uri', award.uri
-                , 'amount', award.award_amount
-            ))) AS awards
-            FROM share_throughawards AS throughaward
-                JOIN share_award AS award ON throughaward.award_id = award.id
-            WHERE throughaward.funder_id = agent_relation.id
-        ) AS awards ON agent_relation.type = 'share.funder'
+        # Gather all the agents in one query, for use below
+        '''
+        all_related_agents AS (
+            SELECT
+                agent_relation.creative_work_id AS creativework_id,
+                json_agg(json_strip_nulls(json_build_object(
+                    'id', agent.id
+                    , 'type', agent.type
+                    , 'name', agent.name
+                    , 'given_name', agent.given_name
+                    , 'family_name', agent.family_name
+                    , 'additional_name', agent.additional_name
+                    , 'suffix', agent.suffix
+                    , 'identifiers', COALESCE(identifiers, '{}')
+                    , 'relation_type', agent_relation.type
+                    , 'order_cited', agent_relation.order_cited
+                    , 'cited_as', agent_relation.cited_as
+                    , 'affiliations', COALESCE(affiliations, '[]'::json)
+                    , 'awards', COALESCE(awards, '[]'::json)
+                ))) AS related_agents
+            FROM share_agentworkrelation AS agent_relation
+                JOIN share_agent AS agent ON agent_relation.agent_id = agent.id
 
-        WHERE agent_relation.creative_work_id IN (SELECT id FROM pks)
-        GROUP BY agent_relation.creative_work_id
-    ),
-    results AS (
-        SELECT creativework.id, json_build_object(
-            'id', creativework.id
-            , 'type', creativework.type
-            , 'title', creativework.title
-            , 'description', creativework.description
-            , 'is_deleted', creativework.is_deleted
-            , 'language', creativework.language
-            , 'date_created', creativework.date_created
-            , 'date_modified', creativework.date_modified
-            , 'date_updated', creativework.date_updated
-            , 'date_published', creativework.date_published
-            , 'registration_type', creativework.registration_type
-            , 'withdrawn', creativework.withdrawn
-            , 'justification', creativework.justification
-            , 'tags', COALESCE(tags, '{}')
-            , 'identifiers', COALESCE(identifiers, '{}')
-            , 'sources', COALESCE(sources, '{}')
-            , 'subjects', COALESCE(subjects.original, '{}')
-            , 'subject_synonyms', COALESCE(subjects.synonyms, '{}')
-            , 'related_agents', COALESCE(related_agents, '{}')
-            , 'retractions', COALESCE(retractions, '{}')
-            , 'lineage', COALESCE(lineage, '{}')
-        ) AS _source
-        FROM share_creativework AS creativework
-
-        LEFT JOIN LATERAL (
-            SELECT sources FROM all_sources WHERE creativework_id = creativework.id
-        ) AS sources ON TRUE
-
-        LEFT JOIN LATERAL (
-            SELECT tags FROM all_tags WHERE creativework_id = creativework.id
-        ) AS tags ON TRUE
-
-        LEFT JOIN LATERAL (
-            SELECT related_agents FROM all_related_agents WHERE creativework_id = creativework.id
-        ) AS related_agents ON TRUE
-
-        LEFT JOIN LATERAL (
-            SELECT array_agg(identifier.uri) AS identifiers
-            FROM share_workidentifier AS identifier
-            WHERE identifier.creative_work_id = creativework.id
-        ) AS identifiers ON TRUE
-
-        LEFT JOIN LATERAL (
-            WITH RECURSIVE subject_names(synonym, taxonomy, parent_id, path) AS (
+            LEFT JOIN LATERAL (
                 SELECT
-                    FALSE,
-                    CASE WHEN source.name = %(system_user)s THEN %(central_taxonomy)s ELSE source.long_title END,
-                    parent_id,
-                    share_subject.name
-                FROM share_throughsubjects
-                    JOIN share_subject ON share_subject.id = share_throughsubjects.subject_id
-                    JOIN share_subjecttaxonomy AS taxonomy ON share_subject.taxonomy_id = taxonomy.id
-                    JOIN share_source AS source ON taxonomy.source_id = source.id
-                WHERE share_throughsubjects.creative_work_id = creativework.id
-                    AND NOT share_throughsubjects.is_deleted
-                UNION ALL
+                    array_agg(identifier.uri) AS identifiers
+                FROM share_agentidentifier AS identifier
+                WHERE identifier.agent_id = agent.id
+                AND identifier.scheme != 'mailto'
+                LIMIT 51
+            ) AS identifiers ON TRUE
+
+            LEFT JOIN LATERAL (
+                SELECT json_agg(json_strip_nulls(json_build_object(
+                    'id', affiliated_agent.id
+                    , 'type', affiliated_agent.type
+                    , 'name', affiliated_agent.name
+                    , 'affiliation_type', affiliation.type
+                ))) AS affiliations
+                FROM share_agentrelation AS affiliation
+                    JOIN share_agent AS affiliated_agent ON affiliation.related_id = affiliated_agent.id
+                WHERE affiliation.subject_id = agent.id AND affiliated_agent.type != 'share.person'
+            ) AS affiliations ON (agent.type = 'share.person')
+
+            LEFT JOIN LATERAL (
+                SELECT json_agg(json_strip_nulls(json_build_object(
+                    'id', award.id
+                    , 'type', 'share.award'
+                    , 'date', award.date
+                    , 'name', award.name
+                    , 'description', award.description
+                    , 'uri', award.uri
+                    , 'amount', award.award_amount
+                ))) AS awards
+                FROM share_throughawards AS throughaward
+                    JOIN share_award AS award ON throughaward.award_id = award.id
+                WHERE throughaward.funder_id = agent_relation.id
+            ) AS awards ON agent_relation.type = 'share.funder'
+
+            WHERE agent_relation.creative_work_id IN (SELECT id FROM pks)
+            GROUP BY agent_relation.creative_work_id
+        ),
+        '''
+
+        # For each work, construct the JSON that (after post-processing) will be sent to elasticsearch
+        '''
+        results AS (
+            SELECT creativework.id, json_build_object(
+                'id', creativework.id
+                , 'type', creativework.type
+                , 'title', creativework.title
+                , 'description', creativework.description
+                , 'is_deleted', creativework.is_deleted
+                , 'language', creativework.language
+                , 'date_created', creativework.date_created
+                , 'date_modified', creativework.date_modified
+                , 'date_updated', creativework.date_updated
+                , 'date_published', creativework.date_published
+                , 'registration_type', creativework.registration_type
+                , 'withdrawn', creativework.withdrawn
+                , 'justification', creativework.justification
+                , 'tags', COALESCE(tags, '{}')
+                , 'identifiers', COALESCE(identifiers, '{}')
+                , 'sources', COALESCE(sources, '{}')
+                , 'subjects', COALESCE(subjects.original, '{}')
+                , 'subject_synonyms', COALESCE(subjects.synonyms, '{}')
+                , 'related_agents', COALESCE(related_agents, '{}')
+                , 'retractions', COALESCE(retractions, '{}')
+                , 'lineage', COALESCE(lineage, '{}')
+            ) AS _source
+            FROM share_creativework AS creativework
+
+            LEFT JOIN LATERAL (
+                SELECT sources FROM all_sources WHERE creativework_id = creativework.id
+            ) AS sources ON TRUE
+
+            LEFT JOIN LATERAL (
+                SELECT tags FROM all_tags WHERE creativework_id = creativework.id
+            ) AS tags ON TRUE
+
+            LEFT JOIN LATERAL (
+                SELECT related_agents FROM all_related_agents WHERE creativework_id = creativework.id
+            ) AS related_agents ON TRUE
+
+            LEFT JOIN LATERAL (
+                SELECT array_agg(identifier.uri) AS identifiers
+                FROM share_workidentifier AS identifier
+                WHERE identifier.creative_work_id = creativework.id
+            ) AS identifiers ON TRUE
+        '''
+
+        # Get the full subject lineage for each subject on the work (subjects.original),
+        # as well as their synonyms in the central taxonomy (subjects.synonyms)
+        '''
+            LEFT JOIN LATERAL (
+                WITH RECURSIVE subject_names(synonym, taxonomy, parent_id, path) AS (
                     SELECT
-                        TRUE, %(central_taxonomy)s, central.parent_id, central.name
+                        FALSE,
+                        CASE WHEN source.name = %(system_user)s THEN %(central_taxonomy)s ELSE source.long_title END,
+                        parent_id,
+                        share_subject.name
                     FROM share_throughsubjects
                         JOIN share_subject ON share_subject.id = share_throughsubjects.subject_id
-                        JOIN share_subject AS central ON central.id = share_subject.central_synonym_id
+                        JOIN share_subjecttaxonomy AS taxonomy ON share_subject.taxonomy_id = taxonomy.id
+                        JOIN share_source AS source ON taxonomy.source_id = source.id
                     WHERE share_throughsubjects.creative_work_id = creativework.id
                         AND NOT share_throughsubjects.is_deleted
+                    UNION ALL
+                        SELECT
+                            TRUE, %(central_taxonomy)s, central.parent_id, central.name
+                        FROM share_throughsubjects
+                            JOIN share_subject ON share_subject.id = share_throughsubjects.subject_id
+                            JOIN share_subject AS central ON central.id = share_subject.central_synonym_id
+                        WHERE share_throughsubjects.creative_work_id = creativework.id
+                            AND NOT share_throughsubjects.is_deleted
 
-                UNION ALL
-                    SELECT
-                        synonym,
-                        child.taxonomy,
-                        parent.parent_id,
-                        concat_ws(%(subject_delimiter)s, parent.name, path)
-                    FROM subject_names AS child
-                        INNER JOIN share_subject AS parent ON child.parent_id = parent.id
-            ) SELECT
-                (
-                    SELECT array_agg(DISTINCT concat_ws(%(subject_delimiter)s, taxonomy, path))
-                    FROM subject_names
-                    WHERE NOT synonym AND parent_id IS NULL
-                ) AS original,
-                (
-                    SELECT array_agg(DISTINCT concat_ws(%(subject_delimiter)s, taxonomy, path))
-                    FROM subject_names
-                    WHERE synonym AND parent_id IS NULL
-                ) AS synonyms
-        ) AS subjects ON TRUE
+                    UNION ALL
+                        SELECT
+                            synonym,
+                            child.taxonomy,
+                            parent.parent_id,
+                            concat_ws(%(subject_delimiter)s, parent.name, path)
+                        FROM subject_names AS child
+                            INNER JOIN share_subject AS parent ON child.parent_id = parent.id
+                ) SELECT
+                    (
+                        SELECT array_agg(DISTINCT concat_ws(%(subject_delimiter)s, taxonomy, path))
+                        FROM subject_names
+                        WHERE NOT synonym AND parent_id IS NULL
+                    ) AS original,
+                    (
+                        SELECT array_agg(DISTINCT concat_ws(%(subject_delimiter)s, taxonomy, path))
+                        FROM subject_names
+                        WHERE synonym AND parent_id IS NULL
+                    ) AS synonyms
+            ) AS subjects ON TRUE
+        '''
 
-        LEFT JOIN LATERAL (
-            WITH RECURSIVE ancestors(depth, id, type, title, identifiers) AS (
-                VALUES (0, creativework.id, NULL, NULL, NULL::text[])
-                UNION (
-                    SELECT
-                        child.depth + 1, parent.id, parent.type, parent.title, COALESCE(parent_identifiers.identifiers, '{}')
-                    FROM ancestors AS child
-                        JOIN share_workrelation AS work_relation ON child.id = work_relation.subject_id
-                        JOIN share_creativework AS parent ON work_relation.related_id = parent.id
-                        LEFT JOIN LATERAL (
-                            SELECT array_agg(identifier.uri) AS identifiers
-                            FROM share_workidentifier AS identifier
-                            WHERE identifier.creative_work_id = parent.id
-                        ) AS parent_identifiers ON TRUE
-                    WHERE work_relation.type = %(parent_relation)s
-                        AND child.depth < %(work_ancestors_depth)s
-                        AND NOT parent.is_deleted
-                    LIMIT 1
+        # Find the work's parent/grandparent/great-grandparent
+        '''
+            LEFT JOIN LATERAL (
+                WITH RECURSIVE ancestors(depth, id, type, title, identifiers) AS (
+                    VALUES (0, creativework.id, NULL, NULL, NULL::text[])
+                    UNION (
+                        SELECT
+                            child.depth + 1, parent.id, parent.type, parent.title, COALESCE(parent_identifiers.identifiers, '{}')
+                        FROM ancestors AS child
+                            JOIN share_workrelation AS work_relation ON child.id = work_relation.subject_id
+                            JOIN share_creativework AS parent ON work_relation.related_id = parent.id
+                            LEFT JOIN LATERAL (
+                                SELECT array_agg(identifier.uri) AS identifiers
+                                FROM share_workidentifier AS identifier
+                                WHERE identifier.creative_work_id = parent.id
+                            ) AS parent_identifiers ON TRUE
+                        WHERE work_relation.type = %(parent_relation)s
+                            AND child.depth < %(work_ancestors_depth)s
+                            AND NOT parent.is_deleted
+                        LIMIT 1
+                    )
                 )
-            )
-            SELECT json_agg(json_strip_nulls(json_build_object(
-                    'id', id
-                    , 'type', type
-                    , 'title', title
-                    , 'identifiers', identifiers
-                ))) AS lineage
-            FROM ancestors
-            WHERE depth > 0
-        ) AS lineage ON TRUE
+                SELECT json_agg(json_strip_nulls(json_build_object(
+                        'id', id
+                        , 'type', type
+                        , 'title', title
+                        , 'identifiers', identifiers
+                    ))) AS lineage
+                FROM ancestors
+                WHERE depth > 0
+            ) AS lineage ON TRUE
+        '''
 
-        LEFT JOIN LATERAL (
-            SELECT json_agg(json_strip_nulls(json_build_object(
-                    'id', retraction.id
-                    , 'type', retraction.type
-                    , 'title', retraction.title
-                    , 'description', retraction.description
-                    , 'date_created', retraction.date_created
-                    , 'date_modified', retraction.date_modified
-                    , 'date_updated', retraction.date_updated
-                    , 'date_published', retraction.date_published
-                    , 'identifiers', COALESCE(identifiers, '{}')
-                ))) AS retractions
-            FROM share_workrelation AS work_relation
-                JOIN share_creativework AS retraction ON work_relation.subject_id = retraction.id
-                LEFT JOIN LATERAL (
-                    SELECT array_agg(identifier.uri) AS identifiers
-                    FROM share_workidentifier AS identifier
-                    WHERE identifier.creative_work_id = retraction.id
-                ) AS identifiers ON TRUE
-            WHERE work_relation.related_id = creativework.id
-                AND work_relation.type = %(retraction_relation)s
-                AND NOT retraction.is_deleted
-        ) AS retractions ON TRUE
+        # Find works that retract this work
+        '''
+            LEFT JOIN LATERAL (
+                SELECT json_agg(json_strip_nulls(json_build_object(
+                        'id', retraction.id
+                        , 'type', retraction.type
+                        , 'title', retraction.title
+                        , 'description', retraction.description
+                        , 'date_created', retraction.date_created
+                        , 'date_modified', retraction.date_modified
+                        , 'date_updated', retraction.date_updated
+                        , 'date_published', retraction.date_published
+                        , 'identifiers', COALESCE(identifiers, '{}')
+                    ))) AS retractions
+                FROM share_workrelation AS work_relation
+                    JOIN share_creativework AS retraction ON work_relation.subject_id = retraction.id
+                    LEFT JOIN LATERAL (
+                        SELECT array_agg(identifier.uri) AS identifiers
+                        FROM share_workidentifier AS identifier
+                        WHERE identifier.creative_work_id = retraction.id
+                    ) AS identifiers ON TRUE
+                WHERE work_relation.related_id = creativework.id
+                    AND work_relation.type = %(retraction_relation)s
+                    AND NOT retraction.is_deleted
+            ) AS retractions ON TRUE
+        '''
 
-        WHERE creativework.id IN (SELECT id FROM pks)
-        AND creativework.title != ''
-        AND (
-            SELECT COUNT(*) FROM share_workidentifier
-            WHERE share_workidentifier.creative_work_id = creativework.id
-            LIMIT %(max_identifiers)s + 1
-        ) <= %(max_identifiers)s
+        # Exclude works with empty titles or too many identifiers
+        '''
+            WHERE creativework.id IN (SELECT id FROM pks)
+            AND creativework.title != ''
+            AND (
+                SELECT COUNT(*) FROM share_workidentifier
+                WHERE share_workidentifier.creative_work_id = creativework.id
+                LIMIT %(max_identifiers)s + 1
+            ) <= %(max_identifiers)s
+        )
+        '''
     )
-    '''
 
     def query_parameters(self, pks):
         return {


### PR DESCRIPTION
Look at a work's `IsPartOf` relationship as its parent work, and include the closest three ancestors in elasticsearch at `lists.lineage`.

Given several works with lineage:
```
Deeply > Nested > Components > To > Make > A > Good > Long > Lineage
```
The "Long" work will be indexed with:
```
"lineage": [
    {   
        "identifiers": [
            "urn://share/io.osf:83u96",
            "http://staging-api.osf.io/v2/nodes/83u96/",
            "http://staging.osf.io/83u96/"
        ],  
        "type": "project",
        "title": "Make",
        "types": [
            "project",
            "publication",
            "creative work"
        ],  
        "id": "3314A-94F-6B8"
    },  
    {   
        "identifiers": [
            "urn://share/io.osf:3zmxy",
            "http://staging-api.osf.io/v2/nodes/3zmxy/",
            "http://staging.osf.io/3zmxy/"
        ],  
        "type": "project",
        "title": "A",
        "types": [
            "project",
            "publication",
            "creative work"
        ],  
        "id": "3306B-E73-7C9"
    },  
    {   
        "identifiers": [
            "urn://share/io.osf:ay67d",
            "http://staging-api.osf.io/v2/nodes/ay67d/",
            "http://staging.osf.io/ay67d/"
        ],  
        "type": "project",
        "title": "Good",
        "types": [
            "project",
            "publication",
            "creative work"
        ],  
        "id": "3322F-F86-A2F"
    }   
]   
```

Also, tidy up the work fetcher SQL to make it slightly more friendly.

https://openscience.atlassian.net/browse/SHARE-1000