### PR TITLE
[Improvement][SHARE-518] Enable edu.columbia harvester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changed
 * Collect metadata in MODS format from UA Campus Repository
+* Update columbia.edu harvester source config (disabled set to false)
 
 ## Fixed
 * Backfill CHANGELOG.md to include `2.10.0` and `2.11.0`

--- a/share/sources/edu.columbia/source.yaml
+++ b/share/sources/edu.columbia/source.yaml
@@ -1,6 +1,6 @@
 configs:
 - base_url: http://academiccommons.columbia.edu/catalog/oai
-  disabled: true
+  disabled: false
   earliest_date: null
   harvester: oai
   harvester_kwargs: {metadata_prefix: oai_dc}


### PR DESCRIPTION
## Goal 
Enable Columbia's harvester. It's already enabled on production but we need to keep production and the config in sync.

## Ticket 
https://openscience.atlassian.net/browse/SHARE-518