### PR TITLE
[SHARE-1000][Fix] When a work is updated, also reindex related works

### DIFF
--- a/share/tasks.py
+++ b/share/tasks.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db import transaction
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
 from django.db import IntegrityError
@@ -119,6 +120,39 @@ def disambiguate(self, normalized_id):
     updated_works = set(x.id for x in updated if isinstance(x, AbstractCreativeWork))
     existing_works = set(n.instance.id for n in cg.nodes if isinstance(n.instance, AbstractCreativeWork))
     ids = list(updated_works | existing_works)
+
+    # Reindex children of any affected works
+    parent_relation = 'share.ispartof'
+    children = AbstractCreativeWork.objects.filter((
+        Q(
+            outgoing_creative_work_relations__type=parent_relation,
+            outgoing_creative_work_relations__related_id__in=ids
+        ) |
+        Q(
+            outgoing_creative_work_relations__type=parent_relation,
+            outgoing_creative_work_relations__related__outgoing_creative_work_relations__type=parent_relation,
+            outgoing_creative_work_relations__related__outgoing_creative_work_relations__related_id__in=ids
+        ) |
+        Q(
+            outgoing_creative_work_relations__type=parent_relation,
+            outgoing_creative_work_relations__related__outgoing_creative_work_relations__type=parent_relation,
+            outgoing_creative_work_relations__related__outgoing_creative_work_relations__related__outgoing_creative_work_relations__type=parent_relation,
+            outgoing_creative_work_relations__related__outgoing_creative_work_relations__related__outgoing_creative_work_relations__related_id__in=ids
+        )),
+        is_deleted=False
+    ).values_list('id', flat=True)
+
+    # Reindex works retracted by any affected works
+    retraction_relation = 'share.retracts'
+    retracted = AbstractCreativeWork.objects.filter(
+        incoming_creative_work_relations__type=retraction_relation,
+        incoming_creative_work_relations__subject_id__in=ids,
+        is_deleted=False
+    ).values_list('id', flat=True)
+
+    ids.extend(children)
+    ids.extend(retracted)
+    ids = set(ids)
 
     try:
         SearchIndexer(self.app).index('creativework', *ids)

--- a/tests/share/search/test_indexer.py
+++ b/tests/share/search/test_indexer.py
@@ -1,0 +1,64 @@
+import pytest
+
+from share import models
+from share.search import SearchIndexer
+
+from tests import factories
+
+
+class TestIdsToReindex:
+
+    @pytest.mark.parametrize('model', [models.AbstractAgent, models.Tag, models.Source])
+    @pytest.mark.parametrize('pks', [set(), {1}, {1, 2, 3}])
+    def test_noops(self, model, pks):
+        result = SearchIndexer(None).pks_to_reindex(model, pks)
+        assert result == pks
+
+    @pytest.mark.django_db
+    def test_related_works(self):
+        def part_of(child_work, parent_work):
+            factories.AbstractWorkRelationFactory(
+                type='share.ispartof',
+                subject=child_work,
+                related=parent_work
+            )
+
+        def retracts(retraction, work):
+            factories.AbstractWorkRelationFactory(
+                type='share.retracts',
+                subject=retraction,
+                related=work
+            )
+
+        child = factories.AbstractCreativeWorkFactory()
+        lost_sibling = factories.AbstractCreativeWorkFactory(is_deleted=True)
+        parent = factories.AbstractCreativeWorkFactory()
+        gparent = factories.AbstractCreativeWorkFactory()
+        ggparent = factories.AbstractCreativeWorkFactory()
+        gggparent = factories.AbstractCreativeWorkFactory()
+
+        retraction = factories.AbstractCreativeWorkFactory()
+
+        part_of(child, parent)
+        part_of(lost_sibling, parent)
+        part_of(parent, gparent)
+        part_of(gparent, ggparent)
+        part_of(ggparent, gggparent)
+        retracts(retraction, child)
+
+        cases = [
+            ({child}, {child}),
+            ({lost_sibling}, {lost_sibling}),
+            ({parent}, {parent, child}),
+            ({gparent}, {gparent, parent, child}),
+            ({ggparent}, {ggparent, gparent, parent, child}),
+            ({gggparent}, {gggparent, ggparent, gparent, parent}),
+            ({retraction}, {retraction, child}),
+            ({retraction, ggparent}, {retraction, ggparent, gparent, parent, child}),
+        ]
+
+        for input, expected in cases:
+            input_ids = {w.id for w in input}
+            expected_ids = {w.id for w in expected}
+            actual_ids = SearchIndexer(None).pks_to_reindex(models.AbstractCreativeWork, input_ids)
+            assert expected_ids == actual_ids


### PR DESCRIPTION
When a work is updated (in the `disambiguate` task), reindex its children children (based on `IsPartOf` relations) and any works it retracts, since the work could be included in the elastic payload for those related works.

https://openscience.atlassian.net/browse/SHARE-1000