### PR TITLE
[SHARE-1008][Improvement] Add author to atom feed

### DIFF
--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -108,6 +108,15 @@ class CreativeWorksRSS(Feed):
         # Link to SHARE curate page
         return '{}{}/{}'.format(settings.SHARE_WEB_URL, item.get('type').replace(' ', ''), item.get('id'))
 
+    def item_author_name(self, item):
+        authors = item.get('contributors', [])
+        if not authors:
+            return 'No authors provided.'
+        elif len(authors) > 1:
+            return prepare_string('{} et al.'.format(authors[0]))
+        else:
+            return prepare_string(authors[0])
+
     def item_pubdate(self, item):
         return parse_date(item.get('date_published'))
 

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -109,13 +109,21 @@ class CreativeWorksRSS(Feed):
         return '{}{}/{}'.format(settings.SHARE_WEB_URL, item.get('type').replace(' ', ''), item.get('id'))
 
     def item_author_name(self, item):
-        authors = item.get('contributors', [])
+        contributor_list = item.get('lists', []).get('contributors', [])
+        creators = [c for c in contributor_list if 'order_cited' in c]
+
+        authors = sorted(
+            creators,
+            key=lambda x: x['order_cited'],
+            reverse=False
+        ) if creators else contributor_list
+
         if not authors:
             return 'No authors provided.'
         elif len(authors) > 1:
-            return prepare_string('{} et al.'.format(authors[0]))
+            return prepare_string('{} et al.'.format(authors[0]['cited_as']))
         else:
-            return prepare_string(authors[0])
+            return prepare_string(authors[0]['cited_as'])
 
     def item_pubdate(self, item):
         return parse_date(item.get('date_published'))

--- a/tests/api/test_feeds.py
+++ b/tests/api/test_feeds.py
@@ -4,7 +4,7 @@ import faker
 
 from lxml import etree
 
-from share.models import AbstractCreativeWork
+from share.models import AbstractCreativeWork, AgentWorkRelation
 from share.util import IDObfuscator
 
 from bots.elasticsearch import tasks
@@ -26,9 +26,18 @@ class TestFeed:
     def fake_items(self, settings, elastic):
         ids = []
         for i in range(11):
+            person_0 = factories.AbstractAgentFactory(type='share.person')
+            person_1 = factories.AbstractAgentFactory(type='share.person')
+
             work = factories.AbstractCreativeWorkFactory(
                 date_published=None if i % 3 == 0 else fake.date_time_this_decade(),
             )
+            if i % 3 == 1:
+                factories.CreatorWorkRelationFactory(creative_work=work, agent=person_0)
+                factories.CreatorWorkRelationFactory(creative_work=work, agent=person_1)
+            if i % 3 == 2:
+                factories.CreatorWorkRelationFactory(creative_work=work, agent=person_0)
+
             # Works without identifiers won't be surfaced in search
             factories.WorkIdentifierFactory(creative_work=work)
 
@@ -61,9 +70,22 @@ class TestFeed:
         assert len(feed.xpath('//atom:entry', namespaces=NAMESPACES)) == 11
 
         for creative_work, entry in zip(works, feed.xpath('//atom:entry', namespaces={'atom': 'http://www.w3.org/2005/Atom'})):
+            try:
+                contributors = AgentWorkRelation.objects.filter(creative_work_id=creative_work.id)
+            except:
+                contributors = None
+
             assert entry.find('atom:title', namespaces=NAMESPACES).text == creative_work.title
             assert entry.find('atom:summary', namespaces=NAMESPACES).text == creative_work.description
             assert entry.find('atom:link', namespaces=NAMESPACES).attrib['href'].endswith(IDObfuscator.encode(creative_work))
+
+            if not contributors:
+                assert entry.find('atom:author', namespaces=NAMESPACES)[0].text == 'No authors provided.'
+            elif len(contributors) > 1:
+                # can't guarentee the order that the contributors will be in
+                assert entry.find('atom:author', namespaces=NAMESPACES)[0].text.endswith('et al.')
+            else:
+                assert entry.find('atom:author', namespaces=NAMESPACES)[0].text == contributors[0].cited_as
 
             if getattr(creative_work, order):
                 assert entry.find('atom:updated', namespaces=NAMESPACES).text == getattr(creative_work, order).replace(microsecond=0).isoformat()

--- a/tests/factories/share_objects.py
+++ b/tests/factories/share_objects.py
@@ -120,11 +120,11 @@ class AgentWorkRelationFactory(TypedShareObjectFactory):
 
 
 class CreatorWorkRelationFactory(AgentWorkRelationFactory):
-    # order_cited isn't working?
+    order_cited = 0
     type = 'share.creator'
 
     class Meta:
-        model = models.Creator
+        model = models.AbstractAgentWorkRelation
 
 
 class TagFactory(ShareObjectFactory):

--- a/tests/factories/share_objects.py
+++ b/tests/factories/share_objects.py
@@ -19,6 +19,7 @@ __all__ = (
     'ThroughTagsFactory',
     'WorkIdentifierFactory',
     'AbstractWorkRelationFactory',
+    'CreatorWorkRelationFactory',
 )
 
 
@@ -116,6 +117,14 @@ class AgentWorkRelationFactory(TypedShareObjectFactory):
 
     class Meta:
         model = models.AgentWorkRelation
+
+
+class CreatorWorkRelationFactory(AgentWorkRelationFactory):
+    # order_cited isn't working?
+    type = 'share.creator'
+
+    class Meta:
+        model = models.Creator
 
 
 class TagFactory(ShareObjectFactory):


### PR DESCRIPTION
## Purpose
Add authors to atom feed.

## Changes
See "item_author_name" in https://docs.djangoproject.com/en/1.11/ref/contrib/syndication/#feed-class-reference. RSS doesn't support more than one author on the feed and it's really [supposed to be an email](http://www.rssboard.org/rss-specification#ltauthorgtSubelementOfLtitemgt).

Before:
```xml
<entry>
    <title>David's private project</title>
    <link href="http://localhost:8000/share/project/15038-C08-6B2" rel="alternate"/>
    <updated>2017-09-08T18:22:06+00:00</updated>
    <id>http://localhost:8000/share/project/15038-C08-6B2</id>
    <summary type="html"/>
    <category term="project"/>
</entry>
<entry>
    <title>Hello</title>
    <link href="http://localhost:8000/share/project/151AE-1EA-BC3" rel="alternate"/>
    <updated>2017-09-08T18:22:06+00:00</updated>
    <id>http://localhost:8000/share/project/151AE-1EA-BC3</id>
    <summary type="html">fake preprint test thing</summary>
    <category term="project"/>
</entry>
```

After:
```xml
<entry>
    <title>David's private project</title>
    <link href="http://localhost:8000/share/project/15038-C08-6B2" rel="alternate"/>
    <updated>2017-09-08T18:22:06+00:00</updated>
    <author>
        <name>Rebecca Rosenblatt et al.</name>
    </author>
    <id>http://localhost:8000/share/project/15038-C08-6B2</id>
    <summary type="html"/>
    <category term="project"/>
</entry>
<entry>
    <title>Hello</title>
    <link href="http://localhost:8000/share/project/151AE-1EA-BC3" rel="alternate"/>
    <updated>2017-09-08T18:22:06+00:00</updated>
    <author>
        <name>Viola</name>
    </author>
    <id>http://localhost:8000/share/project/151AE-1EA-BC3</id>
    <summary type="html">fake preprint test thing</summary>
    <category term="project"/>
</entry>
```

## QA Notes
* Go to https://staging-share.osf.io/discover
* Filter search results by "OSF" since they always have contributors
* Click on the feed icon next to the search icon to get the atom feed version of the search results
![screen shot 2017-12-08 at 2 40 54 pm](https://user-images.githubusercontent.com/7131985/33782237-dd8f299c-dc25-11e7-85ce-5feeaf753fb2.png)
* Check that the atom feed has an author field for those entries
* Repeat with a source that doesn't have contributors (National Oceanographic Data Center).

The [Feed Intent Viewer chrome extension](https://chrome.google.com/webstore/detail/feed-intent-viewer/oceapojkdgeophkjdijkpbjifdnfimdh) can format the atom feed results for you so you can actually read them.
