### PR TITLE
[SHARE-1019][Fix] Disable persistent DB connections

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -210,7 +210,7 @@ DATABASES = {
         'HOST': os.environ.get('DATABASE_HOST', 'localhost'),
         'PORT': os.environ.get('DATABASE_PORT', '5432'),
         'PASSWORD': os.environ.get('DATABASE_PASSWORD', None),
-        'CONN_MAX_AGE': int(os.environ.get('CONN_MAX_AGE', 0 if DEBUG else 60)),
+        'CONN_MAX_AGE': int(os.environ.get('CONN_MAX_AGE', 0)),
         'TEST': {'SERIALIZE': False},
     },
 }


### PR DESCRIPTION
Avoid an apparent connection leak by using (and closing) a separate DB connection for each request.