### PR TITLE
[SHARE-1007][Fix] Add x-throttle-token header to OSF harvester

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -525,6 +525,8 @@ SHARE_WEB_URL = os.environ.get('SHARE_WEB_URL', SHARE_API_URL + EMBER_SHARE_PREF
 SHARE_USER_AGENT = os.environ.get('SHARE_USER_AGENT', 'SHAREbot/{} (+{})'.format(VERSION, SHARE_WEB_URL))
 
 OSF_API_URL = os.environ.get('OSF_API_URL', 'https://staging-api.osf.io').rstrip('/') + '/'
+OSF_BYPASS_THROTTLE_TOKEN = os.environ.get('BYPASS_THROTTLE_TOKEN', None)
+
 DOI_BASE_URL = os.environ.get('DOI_BASE_URL', 'http://dx.doi.org/')
 
 ALLOWED_TAGS = ['abbr', 'acronym', 'b', 'blockquote', 'code', 'em', 'i', 'li', 'ol', 'strong', 'ul']

--- a/share/harvesters/io_osf.py
+++ b/share/harvesters/io_osf.py
@@ -18,7 +18,7 @@ class OSFHarvester(BaseHarvester):
     def build_url(self, start_date, end_date, path, query_params):
         # so prod SHARE doesn't get throttled
         if settings.OSF_BYPASS_THROTTLE_TOKEN:
-            self.requests.headers.update({'X-THROTTLE-TOKEN': settings.OSF_BYPASS_THROTTLE_TOKEN})
+            self.session.headers.update({'X-THROTTLE-TOKEN': settings.OSF_BYPASS_THROTTLE_TOKEN})
 
         url = furl(settings.OSF_API_URL + path)
         url.args['page[size]'] = 100

--- a/share/harvesters/io_osf.py
+++ b/share/harvesters/io_osf.py
@@ -15,12 +15,12 @@ logger = logging.getLogger(__name__)
 class OSFHarvester(BaseHarvester):
     VERSION = 1
 
-    def build_url(self, start_date, end_date, path, query_params):
+    def build_url(self, start_date, end_date):
         # so prod SHARE doesn't get throttled
         if settings.OSF_BYPASS_THROTTLE_TOKEN:
             self.session.headers.update({'X-THROTTLE-TOKEN': settings.OSF_BYPASS_THROTTLE_TOKEN})
 
-        url = furl(settings.OSF_API_URL + path)
+        url = furl(settings.OSF_API_URL + self.kwargs['path'])
         url.args['page[size]'] = 100
         # url.args['filter[public]'] = 'true'
         # OSF turns dates into date @ midnight so we have to go ahead one more day

--- a/share/harvesters/io_osf.py
+++ b/share/harvesters/io_osf.py
@@ -15,8 +15,12 @@ logger = logging.getLogger(__name__)
 class OSFHarvester(BaseHarvester):
     VERSION = 1
 
-    def build_url(self, start_date, end_date):
-        url = furl(settings.OSF_API_URL + self.kwargs['path'])
+    def build_url(self, start_date, end_date, path, query_params):
+        # so prod SHARE doesn't get throttled
+        if settings.OSF_BYPASS_THROTTLE_TOKEN:
+            self.requests.headers.update({'X-THROTTLE-TOKEN': settings.OSF_BYPASS_THROTTLE_TOKEN})
+
+        url = furl(settings.OSF_API_URL + path)
         url.args['page[size]'] = 100
         # url.args['filter[public]'] = 'true'
         # OSF turns dates into date @ midnight so we have to go ahead one more day


### PR DESCRIPTION
*Requires that devops adds the `BYPASS_THROTTLE_TOKEN` as an environment variable on prod. Michael has been notified.* ✅  this has been done

## Purpose
OSF harvest tasks fail, every day. We are getting 429s from the OSF API.

## Changes
Add no throttle header 

## QA notes
Doesn't need QA.