### PR TITLE
[SHARE-1029][Hotfix] Correct links in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+# [2.13.1] - 2018-01-04
+## Fixed
+* Use request context to build URLs in the API instead of SHARE_API_URL setting
+    * Stop displaying `localhost:8000` links
+
+## Added
+* Add `--from` parameter to `fixpreprintdisambiguations` management command
+
 # [2.13.0] - 2017-12-18
 ## Added
 * Support for set blacklists for sources that follow OAI-PMH protocol

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -1,11 +1,12 @@
 import re
 
+from django.urls import reverse
+
 from rest_framework import views, viewsets
 from rest_framework.response import Response
 from rest_framework_json_api import serializers
 
 from share.util import IDObfuscator, InvalidID
-from api.util import absolute_reverse
 
 
 __all__ = ('ShareViewSet', 'RootView')
@@ -43,16 +44,17 @@ class ShareViewSet(viewsets.ViewSet):
 
 class RootView(views.APIView):
     def get(self, request):
-        ret = {
-            'site_banners': absolute_reverse('api:site_banners-list'),
-            'normalizeddata': absolute_reverse('api:normalizeddata-list'),
-            'rawdata': absolute_reverse('api:rawdatum-list'),
-            'sourceregistrations': absolute_reverse('api:sourceregistration-list'),
-            'sources': absolute_reverse('api:source-list'),
-            'users': absolute_reverse('api:user-list'),
-            'schema': absolute_reverse('api:schema'),
-            'status': absolute_reverse('api:status'),
-            'rss': absolute_reverse('api:rss'),
-            'atom': absolute_reverse('api:atom'),
+        links = {
+            'site_banners': 'api:site_banners-list',
+            'normalizeddata': 'api:normalizeddata-list',
+            'rawdata': 'api:rawdatum-list',
+            'sourceregistrations': 'api:sourceregistration-list',
+            'sources': 'api:source-list',
+            'users': 'api:user-list',
+            'schema': 'api:schema',
+            'status': 'api:status',
+            'rss': 'api:rss',
+            'atom': 'api:atom',
         }
+        ret = {k: request.build_absolute_uri(reverse(v)) for k, v in links.items()}
         return Response(ret)

--- a/api/util.py
+++ b/api/util.py
@@ -1,6 +1,4 @@
 from django import http
-from django.conf import settings
-from django.urls import reverse
 
 
 class HttpSmartResponseRedirect(http.HttpResponseRedirect):
@@ -9,7 +7,3 @@ class HttpSmartResponseRedirect(http.HttpResponseRedirect):
 
 class HttpSmartResponsePermanentRedirect(http.HttpResponsePermanentRedirect):
     status_code = 308
-
-
-def absolute_reverse(view_name, *args, **kwargs):
-    return '{}{}'.format(settings.SHARE_API_URL.rstrip('/'), reverse(view_name, *args, **kwargs))

--- a/project/settings.py
+++ b/project/settings.py
@@ -557,7 +557,7 @@ OSF_PREPRINT_PROVIDERS = [
     'LawArXiv',
     'MindRxiv',
     'NutriXiv',
-    'Open Science Framework',
+    'OSF',
     'PaleorXiv',
     'PsyArXiv',
     'SocArXiv',


### PR DESCRIPTION
Use django's `request.build_absolute_uri` to build URLs in the API instead of SHARE_API_URL. 

SHARE_API_URL is intended for internal access to the API.

Also, add a `--from` parameter to `fixpreprintdisambiguations`, to allow narrowing its scope a little.