### PR TITLE
[SHARE-1021][Improvement] Add type mapping for University of Cambridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 ## Added
 * Type map for Columbia Academic Commons (edu.columbia)
+* Type map for University of Cambridge (uk.cambridge)
 
 # [2.14.0] - 2018-01-10
 ## Added

--- a/share/sources/uk.cambridge/source.yaml
+++ b/share/sources/uk.cambridge/source.yaml
@@ -14,10 +14,10 @@ configs:
     emitted_type: CreativeWork
     property_list: []
     type_map:
-      Journal Article: article,
-      Book chapter: book,
-      Book or Book Chapter: book,
-      Conference Object: conferencepaper,
+      Journal Article: article
+      Book chapter: book
+      Book or Book Chapter: book
+      Conference Object: conferencepaper
 - base_url: https://www.repository.cam.ac.uk/oai/request
   disabled: true
   earliest_date: null

--- a/share/sources/uk.cambridge/source.yaml
+++ b/share/sources/uk.cambridge/source.yaml
@@ -13,7 +13,12 @@ configs:
     approved_sets: null
     emitted_type: CreativeWork
     property_list: []
-    type_map: {}
+    type_map: {
+      Journal Article: article,
+      Book chapter: book,
+      Book or Book Chapter: book,
+      Conference Object: conferencepaper,
+    }
 - base_url: https://www.repository.cam.ac.uk/oai/request
   disabled: true
   earliest_date: null

--- a/share/sources/uk.cambridge/source.yaml
+++ b/share/sources/uk.cambridge/source.yaml
@@ -13,12 +13,11 @@ configs:
     approved_sets: null
     emitted_type: CreativeWork
     property_list: []
-    type_map: {
+    type_map:
       Journal Article: article,
       Book chapter: book,
       Book or Book Chapter: book,
       Conference Object: conferencepaper,
-    }
 - base_url: https://www.repository.cam.ac.uk/oai/request
   disabled: true
   earliest_date: null


### PR DESCRIPTION
## Purpose 
University of Cambridge asked us to map some types.

## Changes
* Add type mapping for University of Cambridge
* Update CHANGELOG

## Release steps
Run `./manage.py loadsources uk.cambridge --overwrite` after merging on respective environments.