### PR TITLE
[SHARE-1011][Improvement] Add type map to Columbia Academic Commons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# Unreleased
+## Added
+* Type map for Columbia Academic Commons (edu.columbia)
+
 # [2.14.0] - 2018-01-10
 ## Added
 * Allow reading/writing `Source.canonical` at `/api/v2/sources/`
@@ -23,7 +27,7 @@
 * Support for set blacklists for sources that follow OAI-PMH protocol
     * `enforce_set_lists` command to enforce set blacklist and whitelist
 * Set whitelist for UA Campus Repository
-* Support for encrypted json field and start using it in SourceConfig model 
+* Support for encrypted json field and start using it in SourceConfig model
 * Enable Coveralls
 * Include work lineage (based on IsPartOf relations) in the search index payload
 * Add `self` links to objects returned by the API

--- a/share/sources/edu.columbia/source.yaml
+++ b/share/sources/edu.columbia/source.yaml
@@ -12,7 +12,20 @@ configs:
     approved_sets: null
     emitted_type: CreativeWork
     property_list: []
-    type_map: {}
+    type_map:
+      Abstracts (summaries): publication
+      Articles: article
+      Chapters (layout features): publication
+      Conference posters: poster
+      Data (information): dataset
+      Essays: publication
+      Exhibition catalogs: publication
+      Monographs: book
+      Performances (creative events): presentation
+      Presentations (Communicative Events): presentation
+      Reports: report
+      Reviews: publication
+      Theses: thesis
 home_page: http://academiccommons.columbia.edu/
 long_title: Columbia Academic Commons
 name: edu.columbia


### PR DESCRIPTION
## Purpose
Columbia University asked us to map some types.

## Changes
* Add type mapping for Columbia University
* Update CHANGELOG

## Release steps
Run `./manage.py loadsources edu.columbia --overwrite` after merging on respective environments.