### PR TITLE
[SHARE-1034][Improvement] Use `name` instead of `cited_as` in atom feed

### DIFF
--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -120,10 +120,8 @@ class CreativeWorksRSS(Feed):
 
         if not authors:
             return 'No authors provided.'
-        elif len(authors) > 1:
-            return prepare_string('{} et al.'.format(authors[0]['cited_as']))
-        else:
-            return prepare_string(authors[0]['cited_as'])
+        author_name = authors[0]['name'] or authors[0]['cited_as']
+        return prepare_string('{}{}'.format(author_name, ' et al.' if len(authors) > 1 else ''))
 
     def item_pubdate(self, item):
         return parse_date(item.get('date_published'))

--- a/tests/api/test_feeds.py
+++ b/tests/api/test_feeds.py
@@ -73,7 +73,7 @@ class TestFeed:
             try:
                 contributors = list(AbstractAgentWorkRelation.objects.filter(creative_work_id=creative_work.id))
                 first_contributor = AbstractAgentWorkRelation.objects.get(creative_work_id=creative_work.id, order_cited=0)
-            except:
+            except Exception:
                 contributors = None
 
             assert entry.find('atom:title', namespaces=NAMESPACES).text == creative_work.title
@@ -83,9 +83,9 @@ class TestFeed:
             if not contributors:
                 assert entry.find('atom:author', namespaces=NAMESPACES)[0].text == 'No authors provided.'
             elif len(contributors) > 1:
-                assert entry.find('atom:author', namespaces=NAMESPACES)[0].text == '{} et al.'.format(first_contributor.cited_as)
+                assert entry.find('atom:author', namespaces=NAMESPACES)[0].text == '{} et al.'.format(first_contributor.agent.name)
             else:
-                assert entry.find('atom:author', namespaces=NAMESPACES)[0].text == first_contributor.cited_as
+                assert entry.find('atom:author', namespaces=NAMESPACES)[0].text == first_contributor.agent.name
 
             if getattr(creative_work, order):
                 assert entry.find('atom:updated', namespaces=NAMESPACES).text == getattr(creative_work, order).replace(microsecond=0).isoformat()


### PR DESCRIPTION
At `/api/v2/atom`, each entry should have an `<author>` element like
```
<author><name>Steven Loria</name></author>
```
or 
```
<author><name>Steven Loria et al.</name></author>
```
but never `Loria, Steven`.

https://openscience.atlassian.net/browse/SHARE-1034