### PR TITLE
[SHARE-1045] Speed up OAI feed (for real this time)

### DIFF
--- a/share/oaipmh/repository.py
+++ b/share/oaipmh/repository.py
@@ -135,7 +135,7 @@ class OAIRepository:
                     raise
                 self.errors.append(oai_errors.BadArgument('Invalid value for', 'until'))
         if 'set' in kwargs:
-            source_users = ShareUser.objects.filter(source__name=kwargs['set'])
+            source_users = ShareUser.objects.filter(source__name=kwargs['set']).values_list('id', flat=True)
             queryset = queryset.filter(sources__in=source_users)
 
         return queryset


### PR DESCRIPTION
Using a subquery looked faster on staging, but still times out on production. Instead, do two queries so postgres doesn't get confused trying to optimize across both of them.