### PR TITLE
[SHARE-1025] Add "urgent" queues

### DIFF
--- a/api/normalizeddata/views.py
+++ b/api/normalizeddata/views.py
@@ -74,7 +74,7 @@ class NormalizedDataViewSet(ShareViewSet, generics.ListCreateAPIView, generics.R
                 ingest_jobs=ingester.job
             ).order_by('-created_at').values_list('id', flat=True).first()
 
-        async_result = ingest.delay(job_id=ingester.job.id)
+        async_result = ingest.delay(job_id=ingester.job.id, urgent=True)
 
         # TODO Use an actual serializer
         return Response({

--- a/api/search/views.py
+++ b/api/search/views.py
@@ -45,13 +45,13 @@ class ElasticSearchGetOnlyView(views.APIView):
         params = request.query_params.copy()
 
         v = params.pop('v', None)
-        index = settings.ELASTICSEARCH_INDEX
+        index = settings.ELASTICSEARCH['INDEX']
         if v:
             v = 'v{}'.format(v[0])
-            if v not in settings.ELASTICSEARCH_INDEX_VERSIONS:
+            if v not in settings.ELASTICSEARCH['INDEX_VERSIONS']:
                 return http.HttpResponseBadRequest('Invalid search index version')
             index = '{}_{}'.format(index, v)
-        es_url = furl(settings.ELASTICSEARCH_URL).add(path=index, query_params=params).add(path=url_bits.split('/'))
+        es_url = furl(settings.ELASTICSEARCH['URL']).add(path=index, query_params=params).add(path=url_bits.split('/'))
 
         if request.method == 'GET':
             resp = requests.get(es_url)
@@ -75,13 +75,13 @@ class ElasticSearchPostOnlyView(views.APIView):
         params = request.query_params.copy()
 
         v = params.pop('v', None)
-        index = settings.ELASTICSEARCH_INDEX
+        index = settings.ELASTICSEARCH['INDEX']
         if v:
             v = 'v{}'.format(v[0])
-            if v not in settings.ELASTICSEARCH_INDEX_VERSIONS:
+            if v not in settings.ELASTICSEARCH['INDEX_VERSIONS']:
                 return http.HttpResponseBadRequest('Invalid search index version')
             index = '{}_{}'.format(index, v)
-        es_url = furl(settings.ELASTICSEARCH_URL).add(path=index, query_params=params).add(path=url_bits.split('/'))
+        es_url = furl(settings.ELASTICSEARCH['URL']).add(path=index, query_params=params).add(path=url_bits.split('/'))
 
         if request.method == 'POST':
             resp = requests.post(es_url, json=request.data)
@@ -117,13 +117,13 @@ class ElasticSearchView(views.APIView):
             return http.HttpResponseForbidden(reason='Scroll is not supported.')
 
         v = params.pop('v', None)
-        index = settings.ELASTICSEARCH_INDEX
+        index = settings.ELASTICSEARCH['INDEX']
         if v:
             v = 'v{}'.format(v[0])
-            if v not in settings.ELASTICSEARCH_INDEX_VERSIONS:
+            if v not in settings.ELASTICSEARCH['INDEX_VERSIONS']:
                 return http.HttpResponseBadRequest('Invalid search index version')
             index = '{}_{}'.format(index, v)
-        es_url = furl(settings.ELASTICSEARCH_URL).add(path=index, query_params=params).add(path=url_bits.split('/'))
+        es_url = furl(settings.ELASTICSEARCH['URL']).add(path=index, query_params=params).add(path=url_bits.split('/'))
 
         if request.method == 'GET':
             resp = requests.get(es_url)

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -84,7 +84,7 @@ class CreativeWorksRSS(Feed):
 
     def items(self, obj):
         headers = {'Content-Type': 'application/json'}
-        search_url = '{}{}/creativeworks/_search'.format(settings.ELASTICSEARCH_URL, settings.ELASTICSEARCH_INDEX)
+        search_url = '{}{}/creativeworks/_search'.format(settings.ELASTICSEARCH['URL'], settings.ELASTICSEARCH['INDEX'])
         elastic_response = requests.post(search_url, data=json.dumps(obj), headers=headers)
         json_response = elastic_response.json()
 

--- a/api/views/workflow.py
+++ b/api/views/workflow.py
@@ -111,7 +111,7 @@ class V1DataView(views.APIView):
             except KeyError:
                 return Response({'errors': 'Canonical URI not found in uris.', 'data': prelim_data}, status=status.HTTP_400_BAD_REQUEST)
 
-            ingester = Ingester(prelim_data, doc_id).as_user(request.user, 'v1_push').ingest_async()
+            ingester = Ingester(prelim_data, doc_id).as_user(request.user, 'v1_push').ingest_async(urgent=True)
 
             return Response({
                 'task_id': ingester.async_task.id,

--- a/bots/elasticsearch/bot.py
+++ b/bots/elasticsearch/bot.py
@@ -178,10 +178,10 @@ class ElasticSearchBot:
 
     def __init__(self, **kwargs):
         self.es_filter = kwargs.pop('es_filter', None)
-        self.es_index = kwargs.pop('es_index', None) or settings.ELASTICSEARCH_INDEX
+        self.es_index = kwargs.pop('es_index', None) or settings.ELASTICSEARCH['INDEX']
         self.es_models = kwargs.pop('es_models', None)
         self.es_setup = bool(kwargs.pop('es_setup', False))
-        self.es_url = kwargs.pop('es_url', None) or settings.ELASTICSEARCH_URL
+        self.es_url = kwargs.pop('es_url', None) or settings.ELASTICSEARCH['URL']
         self.to_daemon = kwargs.pop('to_daemon', True)
 
         if self.es_models:
@@ -194,7 +194,7 @@ class ElasticSearchBot:
 
     def get_most_recently_modified(self):
         resp = self.es_client.search(
-            index=(self.es_index or settings.ELASTICSEARCH_INDEX),
+            index=(self.es_index or settings.ELASTICSEARCH['INDEX']),
             doc_type='creativeworks',
             body='{"sort": {"date_modified": "desc"}, "size": 1}'
         )
@@ -234,7 +234,7 @@ class ElasticSearchBot:
                         tasks.index_model.apply_async((model.__name__, batch,), {'es_url': self.es_url, 'es_index': self.es_index})
                     else:
                         try:
-                            SearchIndexer(celery.current_app).index(model.__name__, *batch, index=self.es_index if self.es_index != settings.ELASTICSEARCH_INDEX else None)
+                            SearchIndexer(celery.current_app).index(model.__name__, *batch, index=self.es_index if self.es_index != settings.ELASTICSEARCH['INDEX'] else None)
                         except ValueError:
                             logger.warning('Not sending model type %r to the SearchIndexer', model)
 

--- a/bots/elasticsearch/tasks.py
+++ b/bots/elasticsearch/tasks.py
@@ -56,8 +56,8 @@ def update_elasticsearch(self, filter=None, index=None, models=None, setup=False
 @celery.shared_task(bind=True)
 def index_model(self, model_name, ids, es_url=None, es_index=None):
     # TODO This method should not have to exist anymore
-    es_client = Elasticsearch(es_url or settings.ELASTICSEARCH_URL, retry_on_timeout=True, timeout=settings.ELASTICSEARCH_TIMEOUT)
-    action_gen = indexing.ElasticsearchActionGenerator([settings.ELASTICSEARCH_INDEX], [indexing.FakeMessage(model_name, ids)])
+    es_client = Elasticsearch(es_url or settings.ELASTICSEARCH['URL'], retry_on_timeout=True, timeout=settings.ELASTICSEARCH['TIMEOUT'])
+    action_gen = indexing.ElasticsearchActionGenerator([settings.ELASTICSEARCH['INDEX']], [indexing.FakeMessage(model_name, ids)])
     stream = helpers.streaming_bulk(es_client, (x for x in action_gen if x), max_chunk_bytes=10 * 1024 ** 2, raise_on_error=False)
 
     for ok, resp in stream:
@@ -68,9 +68,9 @@ def index_model(self, model_name, ids, es_url=None, es_index=None):
 @celery.shared_task(bind=True)
 def index_sources(self, es_index=None, es_url=None, timeout=None):
     errors = []
-    es_client = Elasticsearch(es_url or settings.ELASTICSEARCH_URL, retry_on_timeout=True, timeout=settings.ELASTICSEARCH_TIMEOUT)
+    es_client = Elasticsearch(es_url or settings.ELASTICSEARCH['URL'], retry_on_timeout=True, timeout=settings.ELASTICSEARCH['TIMEOUT'])
 
-    for ok, resp in helpers.streaming_bulk(es_client, SourceBulkStreamHelper(es_index or settings.ELASTICSEARCH_INDEX), raise_on_error=False):
+    for ok, resp in helpers.streaming_bulk(es_client, SourceBulkStreamHelper(es_index or settings.ELASTICSEARCH['INDEX']), raise_on_error=False):
         if not ok:
             logger.warning(resp)
         else:
@@ -109,10 +109,10 @@ class SourceBulkStreamHelper:
 
 
 def count_es(es_url, es_index, min_date, max_date):
-    es_client = Elasticsearch(es_url or settings.ELASTICSEARCH_URL, retry_on_timeout=True, timeout=settings.ELASTICSEARCH_TIMEOUT)
+    es_client = Elasticsearch(es_url or settings.ELASTICSEARCH['URL'], retry_on_timeout=True, timeout=settings.ELASTICSEARCH['TIMEOUT'])
 
     return es_client.count(
-        index=(es_index or settings.ELASTICSEARCH_INDEX),
+        index=(es_index or settings.ELASTICSEARCH['INDEX']),
         doc_type='creativeworks',
         body={
             'query': {

--- a/share/graphql/query.py
+++ b/share/graphql/query.py
@@ -29,7 +29,7 @@ class Query(graphene.ObjectType):
     me = graphene.Field(User)
     sources = graphene.List(Source, limit=graphene.Int(), offset=graphene.Int())
 
-    client = Elasticsearch(settings.ELASTICSEARCH_URL, retry_on_timeout=True, timeout=30)
+    client = Elasticsearch(settings.ELASTICSEARCH['URL'], retry_on_timeout=True, timeout=30)
 
     agent = graphene.Field(AbstractAgent, id=graphene.String(), resolver=IDObfuscator.resolver)
     creative_work = graphene.Field(AbstractCreativeWork, id=graphene.String(), resolver=IDObfuscator.resolver)
@@ -46,7 +46,7 @@ class Query(graphene.ObjectType):
         args.setdefault('from', 0)
         args.setdefault('size', 10)
 
-        resp = Query.client.search(index=settings.ELASTICSEARCH_INDEX, doc_type=args.pop('type'), body=args)
+        resp = Query.client.search(index=settings.ELASTICSEARCH['INDEX'], doc_type=args.pop('type'), body=args)
 
         del resp['_shards']  # No need to expose server information
 

--- a/share/search/daemon.py
+++ b/share/search/daemon.py
@@ -61,12 +61,11 @@ class SearchIndexer(ConsumerMixin):
             return super().run()
         finally:
             logger.warning('%r: Shutting down', self)
-            self.should_stop = True
-            self._pool.shutdown()
+            self.stop()
 
     def stop(self):
         self.should_stop = True
-        self._pool.shutdown()
+        self._pool.shutdown(wait=False)
 
     def get_consumers(self, Consumer, channel):
         queue_settings = settings.ELASTICSEARCH['QUEUE_SETTINGS']
@@ -115,8 +114,7 @@ class SearchIndexer(ConsumerMixin):
         except Exception as e:
             client.captureException()
             logger.exception('%r: _action_loop encountered an unexpected error', self)
-            self.should_stop = True
-            raise SystemExit(1)
+            self.stop()
 
     def _actions(self, size, msgs, timeout=5):
         for _ in range(size):
@@ -169,8 +167,7 @@ class SearchIndexer(ConsumerMixin):
         except Exception as e:
             client.captureException()
             logger.exception('%r: _index_loop encountered an unexpected error', self)
-            self.should_stop = True
-            raise SystemExit(1)
+            self.stop()
 
     def __repr__(self):
         return '<{}({})>'.format(self.__class__.__name__, self.index)

--- a/share/tasks/jobs.py
+++ b/share/tasks/jobs.py
@@ -268,7 +268,7 @@ class IngestJobConsumer(JobConsumer):
 
         return super()._prepare_job(job, *args, **kwargs)
 
-    def _consume_job(self, job, superfluous, force, apply_changes=True, index=True):
+    def _consume_job(self, job, superfluous, force, apply_changes=True, index=True, urgent=False):
         datum = None
 
         # Check whether we've already done transform/regulate
@@ -294,7 +294,7 @@ class IngestJobConsumer(JobConsumer):
             # TODO make this pipeline actually legacy by implementing a new one
             updated_work_ids = self._apply_changes(job, datum)
             if index and updated_work_ids:
-                self._update_index(updated_work_ids)
+                self._update_index(updated_work_ids, urgent)
 
     def _transform(self, job):
         transformer = job.suid.source_config.get_transformer()
@@ -357,6 +357,6 @@ class IngestJobConsumer(JobConsumer):
 
         return list(updated_works | existing_works)
 
-    def _update_index(self, work_ids):
+    def _update_index(self, work_ids, urgent):
         indexer = SearchIndexer(self.task.app) if self.task else SearchIndexer()
-        indexer.index('creativework', *work_ids)
+        indexer.index('creativework', *work_ids, urgent=urgent)

--- a/share/util/graph.py
+++ b/share/util/graph.py
@@ -289,7 +289,13 @@ class MutableNode:
         If key is the name of a plain attribute in the SHARE schema, set that attribute's value.
         If key is the name of an outgoing edge, expect `value` to be a node ID or a MutableNode. Add an edge from this node to that one.
         If key is the name of incoming edges, raise an error.
+
+        If value is None, same as `del node[key]`
         """
+        if value is None:
+            del self[key]
+            return
+
         # TODO exclude fields not in the SHARE schema
         field = self.model._meta.get_field(key)
         if field.is_relation and key != 'extra':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,13 +193,13 @@ def university_of_whales(change_ids):
 
 @pytest.fixture
 def elastic(settings):
-    settings.ELASTICSEARCH_TIMEOUT = 5
-    settings.ELASTICSEARCH_INDEX = 'test_' + settings.ELASTICSEARCH_INDEX
+    settings.ELASTICSEARCH['TIMEOUT'] = 5
+    settings.ELASTICSEARCH['INDEX'] = 'test_' + settings.ELASTICSEARCH['INDEX']
 
     bot = ElasticSearchBot(es_setup=False)
 
     try:
-        bot.es_client.indices.delete(index=settings.ELASTICSEARCH_INDEX, ignore=[400, 404])
+        bot.es_client.indices.delete(index=settings.ELASTICSEARCH['INDEX'], ignore=[400, 404])
 
         bot.setup()
     except (ConnectionError, ElasticConnectionError):
@@ -207,7 +207,7 @@ def elastic(settings):
 
     yield bot
 
-    bot.es_client.indices.delete(index=settings.ELASTICSEARCH_INDEX, ignore=[400, 404])
+    bot.es_client.indices.delete(index=settings.ELASTICSEARCH['INDEX'], ignore=[400, 404])
 
 
 @pytest.fixture

--- a/tests/share/tasks/test_ingest.py
+++ b/tests/share/tasks/test_ingest.py
@@ -74,7 +74,9 @@ class TestIngestJobConsumer:
         }).as_user(user).setup_ingest(claim_job=True)
 
         with celery_app.pool.acquire(block=True) as connection:
-            with connection.SimpleQueue(settings.ELASTIC_QUEUE, **settings.ELASTIC_QUEUE_SETTINGS) as queue:
+            index = settings.ELASTICSEARCH['ACTIVE_INDEXES'][0]
+            queue_name = settings.ELASTICSEARCH['INDEXES'][index]['DEFAULT_QUEUE']
+            with connection.SimpleQueue(queue_name, **settings.ELASTICSEARCH['QUEUE_SETTINGS']) as queue:
                 queue.clear()
 
                 celery_app.tasks['share.tasks.ingest'](job_id=ingester.job.id)
@@ -94,7 +96,9 @@ class TestIngestJobConsumer:
         }).as_user(user).setup_ingest(claim_job=True)
 
         with celery_app.pool.acquire(block=True) as connection:
-            with connection.SimpleQueue(settings.ELASTIC_QUEUE, **settings.ELASTIC_QUEUE_SETTINGS) as queue:
+            index = settings.ELASTICSEARCH['ACTIVE_INDEXES'][0]
+            queue_name = settings.ELASTICSEARCH['INDEXES'][index]['DEFAULT_QUEUE']
+            with connection.SimpleQueue(queue_name, **settings.ELASTICSEARCH['QUEUE_SETTINGS']) as queue:
                 queue.clear()
 
                 celery_app.tasks['share.tasks.ingest'](job_id=ingester.job.id)

--- a/tests/share/util/test_mutable_graph.py
+++ b/tests/share/util/test_mutable_graph.py
@@ -64,16 +64,31 @@ class TestMutableGraph:
 
     @pytest.mark.parametrize('node_id, key, value', [
         (work_id, 'title', 'title title'),
-        (work_id, 'description', None),
+        (work_id, 'description', 'woo'),
         (identifier_id, 'creative_work', None),
     ])
-    def test_attrs(self, mutable_graph, node_id, key, value):
+    def test_set_attrs(self, mutable_graph, node_id, key, value):
         n = mutable_graph.get_node(node_id)
-        if value is None:
-            del n[key]
-        else:
-            n[key] = value
+        n[key] = value
         assert n[key] == value
+
+    @pytest.mark.parametrize('set_none', [True, False])
+    def test_del_attrs(self, mutable_graph, set_none):
+        work = mutable_graph.get_node(work_id)
+        assert work['title']
+        if set_none:
+            work['title'] = None
+        else:
+            del work['title']
+        assert work['title'] is None
+        assert 'title' not in work.attrs
+
+        identifier = mutable_graph.get_node(identifier_id)
+        assert identifier['creative_work'] == work
+        if set_none:
+            identifier['creative_work'] = None
+        else:
+            del identifier['creative_work']
 
     @pytest.mark.parametrize('node_id, reverse_edge_name, count', [
         (work_id, 'agent_relations', 5),


### PR DESCRIPTION
When there's a large backlog of ingest or indexing tasks, freshly pushed data (e.g. new OSF preprints) go to the back of the queue and may have to wait a long while before they're available in the search index.

This PR adds new "urgent" queues for each bottleneck which allow pushed data to jump to the head of the line. Also, tidies up the elasticsearch settings, including removing the various (completely unused) "priority" settings.

New queue names:
- Ingest tasks: `ingest`, `ingest.urgent`
- Indexing to default search index: `es-share`, `es-share.urgent`
- Indexing to TritonSHARE search index: `es-triton-share`, `es-triton-share.urgent`

Deployment notes:
- Stop workers and wait until `es-index` and `es-index-firehose` queues are empty.
- After deployment, these queues can be deleted.

https://openscience.atlassian.net/browse/SHARE-1025