### PR TITLE
Perf improvements

### DIFF
--- a/share/disambiguation/matcher.py
+++ b/share/disambiguation/matcher.py
@@ -30,11 +30,13 @@ class Matcher:
     def chunk_matches(self, graph):
         self.strategy.initial_pass(graph)
         yield self.strategy._matches
+        self.strategy.clear_matches()
 
         for model, nodes in self._group_nodes_by_model(graph):
             for criteria in self._get_model_criteria(model):
                 criteria.match(self.strategy, nodes, model)
             yield self.strategy._matches
+            self.strategy.clear_matches()
 
     def _group_nodes_by_model(self, graph):
         nodes_by_model = {}

--- a/share/disambiguation/strategies/base.py
+++ b/share/disambiguation/strategies/base.py
@@ -17,6 +17,9 @@ class MatchingStrategy(abc.ABC):
     def has_matches(self, node):
         return bool(self._matches.get(node))
 
+    def clear_matches(self):
+        self._matches = {}
+
     @abc.abstractmethod
     def initial_pass(self, nodes):
         raise NotImplementedError

--- a/share/disambiguation/strategies/database.py
+++ b/share/disambiguation/strategies/database.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class DatabaseStrategy(MatchingStrategy):
     MAX_AGENT_RELATIONS = 300
+    MAX_NAME_LENGTH = 200
 
     def __init__(self, source=None, **kwargs):
         super().__init__(**kwargs)
@@ -119,10 +120,15 @@ class DatabaseStrategy(MatchingStrategy):
                 relation_names = [
                     ParsedRelationNames(r, HumanName(r.cited_as), HumanName(r.agent.name))
                     for r in agent_relations.select_related('agent')
+                    if len(r.cited_as) <= self.MAX_NAME_LENGTH and len(r.agent.name) <= self.MAX_NAME_LENGTH
                 ]
 
                 for node in relation_nodes:
+                    if len(node['cited_as']) > self.MAX_NAME_LENGTH or len(node['agent']['name']) > self.MAX_NAME_LENGTH:
+                        continue
+
                     node_names = ParsedRelationNames(node, HumanName(node['cited_as']), HumanName(node['agent']['name']))
+
                     top_matches = sorted(
                         filter(
                             attrgetter('valid_match'),

--- a/share/management/commands/forceingest.py
+++ b/share/management/commands/forceingest.py
@@ -12,7 +12,7 @@ from share.tasks.jobs import IngestJobConsumer
 from share.util.osf import osf_sources
 
 
-MAX_RETRIES = 10
+MAX_RETRIES = 128
 GRAVEYARD_IDENTIFIERS = [
     'http://osf.io/8bg7d/',  # prod
     'http://staging.osf.io/8hym9/',  # staging


### PR DESCRIPTION
Investigating some memory/performance issues locally yielded a few improvements that might help:
- Faster deduping algorithm for large input graphs
- Skip parsing/deduping unrealistically long names (>200 characters), seems that `nameparser` sometimes chokes

Also allow the `forceingest` script more retries before giving up.
