### PR TITLE
optimize oai-pmh query

### DIFF
--- a/tests/share/test_oaipmh.py
+++ b/tests/share/test_oaipmh.py
@@ -66,7 +66,7 @@ class TestOAIVerbs:
         assert identifiers[0].text == 'oai:share.osf.io:{}'.format(IDObfuscator.encode(all_about_anteaters))
 
     def test_list_records(self, post, all_about_anteaters, django_assert_num_queries):
-        with django_assert_num_queries(2):
+        with django_assert_num_queries(1):
             parsed = oai_request({'verb': 'ListRecords', 'metadataPrefix': 'oai_dc'}, post)
         records = parsed.xpath('//ns0:ListRecords/ns0:record', namespaces=NAMESPACES)
         assert len(records) == 1


### PR DESCRIPTION
sometimes, if a complex-enough query is run on a large-enough table, postgres' planner throws up its hands in defeat and falls back to a more naive execution plan than we might expect.

existing (slow) query:
```sql
SELECT
  table1.id,
  -- (...more fields)
  -- (...a bunch of aggregations with subqueries)
FROM table1
  -- (...joins)
WHERE
  -- (...conditions with subqueries)
LIMIT x
```

new (faster) query:
```sql
SELECT
  table1.id,
  -- (...more fields)
  -- (...a bunch of aggregations with subqueries)
FROM table1
WHERE table1.id in (
  SELECT t1.id
  FROM table1 AS t1
    -- (...joins)
  WHERE
    -- (...conditions with subqueries)
  LIMIT x
)
```

moving the `LIMIT` and complex `WHERE` clause into a subquery guarantees that postgres won't run those aggregations on more rows than necessary