### PR TITLE
[fix] after harvesting, schedule `ingest` tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ env:
     - DATABASE_PORT="54321"
     - PROJECT_DIR="$PWD"
     - WHEELHOUSE="$HOME/.cache/wheelhouse"
-    - LIBXML2_DEB="libxml2_2.7.8.dfsg-5.1ubuntu4.15_amd64.deb"
-    - POSTGRES_DEB="postgresql-9.5_9.5.1-1.pgdg60+1_amd64.deb"
+    - LIBXML2_DEB="libxml2-dbg_2.9.4+dfsg1-7ubuntu3.1_amd64.deb"
+    - POSTGRES_DEB="postgresql-9.5_9.5.13-2.pgdg70+1_amd64.deb"
 
 before_install:
     # cache directories


### PR DESCRIPTION
when creating new `IngestJob`s, we now have to schedule the
corresponding `ingest` celery task as well, thanks to a
decreasingly-temporary hack from a while back (see
commit d94757be0bfc15b42b26c30a6288af574c9aaf12)