### PR TITLE
[ENG-1984] static schema

### DIFF
--- a/share/schema/__init__.py
+++ b/share/schema/__init__.py
@@ -1,0 +1,50 @@
+import yaml
+from typing import Set, Union
+
+from share.schema.loader import SchemaLoader
+from share.schema.shapes import (
+    ShareV2SchemaType,
+    ShareV2SchemaAttribute,
+    ShareV2SchemaRelation,
+)
+
+
+class ShareV2Schema:
+    _schema_types = None  # singleton
+    _schema_fields = None  # singleton
+
+    @classmethod
+    def load_schema(cls):
+        with open('share/schema/schema-spec.yaml') as fobj:
+            type_spec_list = yaml.load(fobj)
+        loader = SchemaLoader(type_spec_list)
+        cls._schema_types = loader.schema_types
+        cls._schema_fields = loader.schema_fields
+
+    @property
+    def schema_types(self):
+        if ShareV2Schema._schema_types is None:
+            ShareV2Schema.load_schema()
+        return ShareV2Schema._schema_types
+
+    @property
+    def schema_fields(self):
+        if ShareV2Schema._schema_fields is None:
+            ShareV2Schema.load_schema()
+        return ShareV2Schema._schema_fields
+
+    def get_type(self, type_name) -> ShareV2SchemaType:
+        return self.schema_types[type_name.lower()]
+
+    def get_field(self, type_name, field_name) -> Union[ShareV2SchemaAttribute, ShareV2SchemaRelation]:
+        concrete_type = self.get_type(type_name).concrete_type
+        key = (concrete_type, field_name.lower())
+        return self.schema_fields[key]
+
+    def get_type_names(self, concrete_type) -> Set[str]:
+        lower_concrete_type = concrete_type.lower()
+        return {
+            schema_type.name
+            for schema_type in self.schema_types.values()
+            if schema_type.concrete_type == lower_concrete_type
+        }

--- a/share/schema/__init__.py
+++ b/share/schema/__init__.py
@@ -1,6 +1,7 @@
 import yaml
 from typing import Set, Union
 
+from share.schema.exceptions import SchemaKeyError
 from share.schema.loader import SchemaLoader
 from share.schema.shapes import (
     ShareV2SchemaType,
@@ -34,12 +35,18 @@ class ShareV2Schema:
         return ShareV2Schema._schema_fields
 
     def get_type(self, type_name) -> ShareV2SchemaType:
-        return self.schema_types[type_name.lower()]
+        try:
+            return self.schema_types[type_name.lower()]
+        except KeyError:
+            raise SchemaKeyError(f'type "{type_name}" not found in SHARE schema')
 
     def get_field(self, type_name, field_name) -> Union[ShareV2SchemaAttribute, ShareV2SchemaRelation]:
         concrete_type = self.get_type(type_name).concrete_type
         key = (concrete_type, field_name.lower())
-        return self.schema_fields[key]
+        try:
+            return self.schema_fields[key]
+        except KeyError:
+            raise SchemaKeyError(f'field "{type_name}.{field_name}" not found in SHARE schema')
 
     def get_type_names(self, concrete_type) -> Set[str]:
         lower_concrete_type = concrete_type.lower()

--- a/share/schema/exceptions.py
+++ b/share/schema/exceptions.py
@@ -1,0 +1,5 @@
+from share.exceptions import ShareException
+
+
+class SchemaLoadError(ShareException):
+    pass

--- a/share/schema/exceptions.py
+++ b/share/schema/exceptions.py
@@ -3,3 +3,7 @@ from share.exceptions import ShareException
 
 class SchemaLoadError(ShareException):
     pass
+
+
+class SchemaKeyError(ShareException):
+    pass

--- a/share/schema/loader.py
+++ b/share/schema/loader.py
@@ -1,0 +1,148 @@
+from share.schema.exceptions import SchemaLoadError
+from share.schema.shapes import (
+    RelationShape,
+    AttributeDataType,
+    AttributeDataFormat,
+    ShareV2SchemaAttribute,
+    ShareV2SchemaRelation,
+    ShareV2SchemaType,
+)
+
+
+class SchemaLoader:
+    def __init__(self, type_spec_list):
+        self.schema_types = {}
+        self.schema_fields = {}
+        self.explicit_field_names = {}
+
+        try:
+            self.concrete_types = set(
+                type_spec['concrete_type'].lower()
+                for type_spec in type_spec_list
+            )
+            self._load_all_attrs_and_relations(type_spec_list)
+            self._load_types(type_spec_list)
+        except KeyError as error:
+            raise SchemaLoadError(error)
+
+    def _load_all_attrs_and_relations(self, type_spec_list):
+        for type_spec in type_spec_list:
+            concrete_type = type_spec['concrete_type']
+            self._load_attributes(concrete_type, type_spec.get('attributes', []))
+            self._load_relations(concrete_type, type_spec.get('relations', []))
+
+    def _load_types(self, type_spec_list):
+        # assumes load_all_attrs_and_relations has already been called
+        for type_spec in type_spec_list:
+            concrete_type = type_spec['concrete_type']
+            type_tree = type_spec.get('type_tree', None)
+
+            if type_tree:
+                self._add_type_tree(concrete_type, type_tree)
+            else:
+                self._add_type(concrete_type, concrete_type)
+
+    def _load_attributes(self, concrete_type, attr_list):
+        for attr_dict in attr_list:
+            attr = self._build_attribute(attr_dict)
+            self._add_field(concrete_type, attr)
+
+    def _load_relations(self, concrete_type, relation_list):
+        for relation_dict in relation_list:
+            relation = self._build_relation(relation_dict)
+            self._add_relation(concrete_type, relation)
+            if relation.inverse_relation:
+                self._add_inverse_relation(concrete_type, relation)
+
+    def _add_inverse_relation(self, concrete_type, relation):
+        inverse_relation_shape = {
+            RelationShape.MANY_TO_MANY: RelationShape.MANY_TO_MANY,
+            RelationShape.MANY_TO_ONE: RelationShape.ONE_TO_MANY,
+            RelationShape.ONE_TO_MANY: RelationShape.MANY_TO_ONE,
+        }[relation.relation_shape]
+
+        inverse_relation = ShareV2SchemaRelation(
+            name=relation.inverse_relation,
+            relation_shape=inverse_relation_shape,
+            related_concrete_type=concrete_type,
+            inverse_relation=relation.name,
+            is_implicit=True,
+        )
+        self._add_relation(relation.related_concrete_type, inverse_relation)
+
+    def _add_type(self, concrete_type, type_name, distance_from_concrete_type=0):
+        lower_name = type_name.lower()
+        self.schema_types[lower_name] = ShareV2SchemaType(
+            name=lower_name,
+            concrete_type=concrete_type,
+            distance_from_concrete_type=distance_from_concrete_type,
+            explicit_fields=set(self.explicit_field_names.get(concrete_type, [])),
+        )
+
+    def _add_type_tree(self, concrete_type, type_tree, depth=1):
+        for type_name, subtree in type_tree.items():
+            self._add_type(concrete_type, type_name, depth)
+            if subtree:
+                self._add_type_tree(concrete_type, subtree, depth + 1)
+
+    def _add_relation(self, concrete_type, relation):
+        key = (concrete_type, relation.name)
+        existing_relation = self.schema_fields.get(key, None)
+        if existing_relation:
+            is_existing_relation_compatible = (
+                existing_relation.is_relation
+                and relation.name == existing_relation.name
+                and relation.relation_shape == existing_relation.relation_shape
+                and relation.related_concrete_type == existing_relation.related_concrete_type
+                and relation.inverse_relation == existing_relation.inverse_relation
+            )
+            if not is_existing_relation_compatible:
+                raise SchemaLoadError(f'relation defined two incompatible ways -- maybe a bad inverse? existing: {existing_relation}  trying to add: {relation}')
+
+            if existing_relation.is_implicit:
+                # let the new relation overwrite the implicit one
+                del self.schema_fields[key]
+            elif relation.is_implicit:
+                return  # no need to do anything -- the same relation already exists
+            else:
+                raise SchemaLoadError(f'conflicting explicit relations (new: {relation} existing: {existing_relation})')
+
+        self._add_field(concrete_type, relation)
+
+    def _add_field(self, concrete_type, attr_or_relation):
+        if concrete_type not in self.concrete_types:
+            raise SchemaLoadError(f'invalid concrete_type ({concrete_type}) on field {attr_or_relation}')
+        name = attr_or_relation.name.lower()
+        key = (concrete_type, name)
+        if key in self.schema_fields:
+            raise SchemaLoadError(f'field defined twice: {key}')
+        self.schema_fields[key] = attr_or_relation
+        if not getattr(attr_or_relation, 'is_implicit', False):
+            self.explicit_field_names.setdefault(concrete_type, []).append(name)
+
+    def _build_attribute(self, attr_dict):
+        return ShareV2SchemaAttribute(
+            # required
+            name=attr_dict['name'],
+            data_type=AttributeDataType[attr_dict['data_type'].upper()],
+
+            # optional
+            is_required=attr_dict.get('is_required', False),
+            data_format=AttributeDataFormat[attr_dict['data_format'].upper()] if 'data_format' in attr_dict else None,
+        )
+
+    def _build_relation(self, relation_dict):
+        inverse_relation = relation_dict.get('inverse_relation', None)
+        new_relation = ShareV2SchemaRelation(
+            # required
+            name=relation_dict['name'].lower(),
+            relation_shape=RelationShape[relation_dict['relation_shape'].upper()],
+            related_concrete_type=relation_dict['related_concrete_type'].lower(),
+
+            # optional
+            inverse_relation=inverse_relation.lower() if inverse_relation else None,
+            is_required=relation_dict.get('is_required', False),
+        )
+        if new_relation.related_concrete_type not in self.concrete_types:
+            raise SchemaLoadError(f'invalid related_concrete_type on relation {new_relation}')
+        return new_relation

--- a/share/schema/schema-spec.yaml
+++ b/share/schema/schema-spec.yaml
@@ -1,24 +1,24 @@
-- concrete_type: abstractcreativework
+- concrete_type: AbstractCreativeWork
   type_tree:
-    creativework:
-      dataset:
-      patent:
-      poster:
-      publication:
-        article:
-        book:
-        conferencepaper:
-        dissertation:
-        preprint:
-        project:
-        registration:
-        report:
-        thesis:
-        workingpaper:
-      presentation:
-      repository:
-      retraction:
-      software:
+    CreativeWork:
+      DataSet:
+      Patent:
+      Poster:
+      Publication:
+        Article:
+        Book:
+        ConferencePaper:
+        Dissertation:
+        Preprint:
+        Project:
+        Registration:
+        Report:
+        Thesis:
+        WorkingPaper:
+      Presentation:
+      Repository:
+      Retraction:
+      Software:
   attributes:
     - name: title
       data_type: string
@@ -51,32 +51,32 @@
     - name: subjects
       relation_shape: many_to_many
       related_concrete_type: Subject
+      through_concrete_type: ThroughSubjects
       inverse_relation: creative_works
     - name: tags
       relation_shape: many_to_many
       related_concrete_type: Tag
+      through_concrete_type: ThroughTags
       inverse_relation: creative_works
     - name: related_agents
       relation_shape: many_to_many
       related_concrete_type: AbstractAgent
+      through_concrete_type: AbstractAgentWorkRelation
       inverse_relation: related_works
     - name: related_works
       relation_shape: many_to_many
       related_concrete_type: AbstractCreativeWork
+      through_concrete_type: AbstractWorkRelation
       inverse_relation: related_works
-    - name: identifiers
-      relation_shape: one_to_many
-      related_concrete_type: WorkIdentifier
-      inverse_relation: creative_work
 
-- concrete_type: abstractagent
+- concrete_type: AbstractAgent
   type_tree:
-    agent:
-      organization:
-        consortium:
-        department:
-        institution:
-      person:
+    Agent:
+      Organization:
+        Consortium:
+        Department:
+        Institution:
+      Person:
   attributes:
     - name: name
       data_type: string
@@ -96,26 +96,24 @@
     - name: related_agents
       relation_shape: many_to_many
       related_concrete_type: AbstractAgent
+      through_concrete_type: AbstractAgentRelation
       inverse_relation: related_agents
-    - name: identifiers
-      relation_shape: one_to_many
-      related_concrete_type: AgentIdentifier
-      inverse_relation: agent
     - name: related_works
       relation_shape: many_to_many
       related_concrete_type: AbstractCreativeWork
+      through_concrete_type: AbstractAgentWorkRelation
       inverse_relation: related_agents
 
-- concrete_type: abstractagentworkrelation
+- concrete_type: AbstractAgentWorkRelation
   type_tree:
-    agentworkrelation:
-      contributor:
-        creator:
-          principalinvestigator:
-          principalinvestigatorcontact:
-      funder:
-      host:
-      publisher:
+    AgentWorkRelation:
+      Contributor:
+        Creator:
+          PrincipalInvestigator:
+          PrincipalInvestigatorContact:
+      Funder:
+      Host:
+      Publisher:
   attributes:
     - name: cited_as
       data_type: string
@@ -128,20 +126,23 @@
       relation_shape: many_to_one
       related_concrete_type: AbstractCreativeWork
       inverse_relation: agent_relations
+      is_required: true
     - name: agent
       relation_shape: many_to_one
       related_concrete_type: AbstractAgent
       inverse_relation: work_relations
+      is_required: true
     - name: awards
       relation_shape: many_to_many
       related_concrete_type: Award
+      through_concrete_type: ThroughAwards
 
-- concrete_type: abstractagentrelation
+- concrete_type: AbstractAgentRelation
   type_tree:
-    agentrelation:
-      isaffiliatedwith:
-      isemployedby:
-      ismemberof:
+    AgentRelation:
+      IsAffiliatedWith:
+      IsEmployedBy:
+      IsMemberOf:
   attributes:
     - name: extra
       data_type: object
@@ -150,29 +151,31 @@
       relation_shape: many_to_one
       related_concrete_type: AbstractAgent
       inverse_relation: outgoing_agent_relations
+      is_required: true
     - name: related
       relation_shape: many_to_one
       related_concrete_type: AbstractAgent
       inverse_relation: incoming_agent_relations
+      is_required: true
 
-- concrete_type: abstractworkrelation
+- concrete_type: AbstractWorkRelation
   type_tree:
-    workrelation:
-      cites:
-      compiles:
-      corrects:
-      discusses:
-      disputes:
-      documents:
-      extends:
-      isderivedfrom:
-      ispartof:
-      issupplementto:
-      references:
-      repliesto:
-      retracts:
-      reviews:
-      usesdatafrom:
+    WorkRelation:
+      Cites:
+      Compiles:
+      Corrects:
+      Discusses:
+      Disputes:
+      Documents:
+      Extends:
+      IsDerivedFrom:
+      IsPartOf:
+      IsSupplementTo:
+      References:
+      RepliesTo:
+      Retracts:
+      Reviews:
+      UsesDataFrom:
   attributes:
     - name: extra
       data_type: object
@@ -181,12 +184,14 @@
       relation_shape: many_to_one
       related_concrete_type: AbstractCreativeWork
       inverse_relation: outgoing_creative_work_relations
+      is_required: true
     - name: related
       relation_shape: many_to_one
       related_concrete_type: AbstractCreativeWork
       inverse_relation: incoming_creative_work_relations
+      is_required: true
 
-- concrete_type: workidentifier
+- concrete_type: WorkIdentifier
   attributes:
     - name: uri
       data_type: string
@@ -198,8 +203,14 @@
       data_type: string
     - name: extra
       data_type: object
+  relations:
+    - name: creative_work
+      relation_shape: many_to_one
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: identifiers
+      is_required: true
 
-- concrete_type: agentidentifier
+- concrete_type: AgentIdentifier
   attributes:
     - name: uri
       data_type: string
@@ -211,8 +222,14 @@
       data_type: string
     - name: extra
       data_type: object
+  relations:
+    - name: agent
+      relation_shape: many_to_one
+      related_concrete_type: AbstractAgent
+      inverse_relation: identifiers
+      is_required: true
 
-- concrete_type: subject
+- concrete_type: Subject
   attributes:
     - name: name
       data_type: string
@@ -233,7 +250,7 @@
       relation_shape: many_to_one
       related_concrete_type: Subject
 
-- concrete_type: throughsubjects
+- concrete_type: ThroughSubjects
   attributes:
     - name: is_deleted
       data_type: boolean
@@ -242,12 +259,14 @@
       relation_shape: many_to_one
       related_concrete_type: Subject
       inverse_relation: work_relations
+      is_required: true
     - name: creative_work
       relation_shape: many_to_one
       related_concrete_type: AbstractCreativeWork
       inverse_relation: subject_relations
+      is_required: true
 
-- concrete_type: tag
+- concrete_type: Tag
   attributes:
     - name: name
       data_type: string
@@ -255,18 +274,20 @@
     - name: extra
       data_type: object
 
-- concrete_type: throughtags
+- concrete_type: ThroughTags
   relations:
     - name: tag
       relation_shape: many_to_one
       related_concrete_type: Tag
       inverse_relation: work_relations
+      is_required: true
     - name: creative_work
       relation_shape: many_to_one
       related_concrete_type: AbstractCreativeWork
       inverse_relation: tag_relations
+      is_required: true
 
-- concrete_type: award
+- concrete_type: Award
   attributes:
     - name: name
       data_type: string
@@ -280,13 +301,15 @@
       data_type: string
       data_format: uri
 
-- concrete_type: throughawards
+- concrete_type: ThroughAwards
   relations:
     - name: funder
       relation_shape: many_to_one
       related_concrete_type: AbstractAgentWorkRelation
       inverse_relation: null
+      is_required: true
     - name: award
       relation_shape: many_to_one
       related_concrete_type: Award
       inverse_relation: null
+      is_required: true

--- a/share/schema/schema-spec.yaml
+++ b/share/schema/schema-spec.yaml
@@ -1,0 +1,292 @@
+- concrete_type: abstractcreativework
+  type_tree:
+    creativework:
+      dataset:
+      patent:
+      poster:
+      publication:
+        article:
+        book:
+        conferencepaper:
+        dissertation:
+        preprint:
+        project:
+        registration:
+        report:
+        thesis:
+        workingpaper:
+      presentation:
+      repository:
+      retraction:
+      software:
+  attributes:
+    - name: title
+      data_type: string
+    - name: description
+      data_type: string
+    - name: is_deleted
+      data_type: boolean
+    - name: date_published
+      data_type: datetime
+    - name: date_updated
+      data_type: datetime
+    - name: free_to_read_type
+      data_type: string
+      data_format: uri
+    - name: free_to_read_date
+      data_type: datetime
+    - name: rights
+      data_type: string
+    - name: language
+      data_type: string
+    - name: registration_type
+      data_type: string
+    - name: withdrawn
+      data_type: boolean
+    - name: justification
+      data_type: string
+    - name: extra
+      data_type: object
+  relations:
+    - name: subjects
+      relation_shape: many_to_many
+      related_concrete_type: Subject
+      inverse_relation: creative_works
+    - name: tags
+      relation_shape: many_to_many
+      related_concrete_type: Tag
+      inverse_relation: creative_works
+    - name: related_agents
+      relation_shape: many_to_many
+      related_concrete_type: AbstractAgent
+      inverse_relation: related_works
+    - name: related_works
+      relation_shape: many_to_many
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: related_works
+    - name: identifiers
+      relation_shape: one_to_many
+      related_concrete_type: WorkIdentifier
+      inverse_relation: creative_work
+
+- concrete_type: abstractagent
+  type_tree:
+    agent:
+      organization:
+        consortium:
+        department:
+        institution:
+      person:
+  attributes:
+    - name: name
+      data_type: string
+    - name: location
+      data_type: string
+    - name: family_name
+      data_type: string
+    - name: given_name
+      data_type: string
+    - name: additional_name
+      data_type: string
+    - name: suffix
+      data_type: string
+    - name: extra
+      data_type: object
+  relations:
+    - name: related_agents
+      relation_shape: many_to_many
+      related_concrete_type: AbstractAgent
+      inverse_relation: related_agents
+    - name: identifiers
+      relation_shape: one_to_many
+      related_concrete_type: AgentIdentifier
+      inverse_relation: agent
+    - name: related_works
+      relation_shape: many_to_many
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: related_agents
+
+- concrete_type: abstractagentworkrelation
+  type_tree:
+    agentworkrelation:
+      contributor:
+        creator:
+          principalinvestigator:
+          principalinvestigatorcontact:
+      funder:
+      host:
+      publisher:
+  attributes:
+    - name: cited_as
+      data_type: string
+    - name: order_cited
+      data_type: integer
+    - name: extra
+      data_type: object
+  relations:
+    - name: creative_work
+      relation_shape: many_to_one
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: agent_relations
+    - name: agent
+      relation_shape: many_to_one
+      related_concrete_type: AbstractAgent
+      inverse_relation: work_relations
+    - name: awards
+      relation_shape: many_to_many
+      related_concrete_type: Award
+
+- concrete_type: abstractagentrelation
+  type_tree:
+    agentrelation:
+      isaffiliatedwith:
+      isemployedby:
+      ismemberof:
+  attributes:
+    - name: extra
+      data_type: object
+  relations:
+    - name: subject
+      relation_shape: many_to_one
+      related_concrete_type: AbstractAgent
+      inverse_relation: outgoing_agent_relations
+    - name: related
+      relation_shape: many_to_one
+      related_concrete_type: AbstractAgent
+      inverse_relation: incoming_agent_relations
+
+- concrete_type: abstractworkrelation
+  type_tree:
+    workrelation:
+      cites:
+      compiles:
+      corrects:
+      discusses:
+      disputes:
+      documents:
+      extends:
+      isderivedfrom:
+      ispartof:
+      issupplementto:
+      references:
+      repliesto:
+      retracts:
+      reviews:
+      usesdatafrom:
+  attributes:
+    - name: extra
+      data_type: object
+  relations:
+    - name: subject
+      relation_shape: many_to_one
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: outgoing_creative_work_relations
+    - name: related
+      relation_shape: many_to_one
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: incoming_creative_work_relations
+
+- concrete_type: workidentifier
+  attributes:
+    - name: uri
+      data_type: string
+      data_format: uri
+      is_required: true
+    - name: host
+      data_type: string
+    - name: scheme
+      data_type: string
+    - name: extra
+      data_type: object
+
+- concrete_type: agentidentifier
+  attributes:
+    - name: uri
+      data_type: string
+      data_format: uri
+      is_required: true
+    - name: host
+      data_type: string
+    - name: scheme
+      data_type: string
+    - name: extra
+      data_type: object
+
+- concrete_type: subject
+  attributes:
+    - name: name
+      data_type: string
+      is_required: true
+    - name: is_deleted
+      data_type: boolean
+    - name: uri
+      data_type: string
+      data_format: uri
+    - name: extra
+      data_type: object
+  relations:
+    - name: parent
+      relation_shape: many_to_one
+      related_concrete_type: Subject
+      inverse_relation: children
+    - name: central_synonym
+      relation_shape: many_to_one
+      related_concrete_type: Subject
+
+- concrete_type: throughsubjects
+  attributes:
+    - name: is_deleted
+      data_type: boolean
+  relations:
+    - name: subject
+      relation_shape: many_to_one
+      related_concrete_type: Subject
+      inverse_relation: work_relations
+    - name: creative_work
+      relation_shape: many_to_one
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: subject_relations
+
+- concrete_type: tag
+  attributes:
+    - name: name
+      data_type: string
+      is_required: true
+    - name: extra
+      data_type: object
+
+- concrete_type: throughtags
+  relations:
+    - name: tag
+      relation_shape: many_to_one
+      related_concrete_type: Tag
+      inverse_relation: work_relations
+    - name: creative_work
+      relation_shape: many_to_one
+      related_concrete_type: AbstractCreativeWork
+      inverse_relation: tag_relations
+
+- concrete_type: award
+  attributes:
+    - name: name
+      data_type: string
+    - name: description
+      data_type: string
+    - name: date
+      data_type: datetime
+    - name: award_amount
+      data_type: integer
+    - name: uri
+      data_type: string
+      data_format: uri
+
+- concrete_type: throughawards
+  relations:
+    - name: funder
+      relation_shape: many_to_one
+      related_concrete_type: AbstractAgentWorkRelation
+      inverse_relation: null
+    - name: award
+      relation_shape: many_to_one
+      related_concrete_type: Award
+      inverse_relation: null

--- a/share/schema/shapes.py
+++ b/share/schema/shapes.py
@@ -27,6 +27,7 @@ class ShareV2SchemaRelation(NamedTuple):
     relation_shape: RelationShape
     related_concrete_type: str
     inverse_relation: str
+    through_concrete_type: Optional[str] = None
     is_required: bool = False
     is_implicit: bool = False
     is_relation: bool = True

--- a/share/schema/shapes.py
+++ b/share/schema/shapes.py
@@ -1,0 +1,32 @@
+from enum import Enum
+from typing import Set, NamedTuple, Optional
+
+
+RelationShape = Enum('RelationShape', ['MANY_TO_MANY', 'MANY_TO_ONE', 'ONE_TO_MANY'])
+AttributeDataType = Enum('AttributeDataType', ['BOOLEAN', 'STRING', 'INTEGER', 'DATETIME', 'OBJECT'])
+AttributeDataFormat = Enum('AttributeDataFormat', ['URI'])
+
+
+class ShareV2SchemaType(NamedTuple):
+    name: str
+    concrete_type: str
+    explicit_fields: Set[str]
+    distance_from_concrete_type: int = 0
+
+
+class ShareV2SchemaAttribute(NamedTuple):
+    name: str
+    data_type: AttributeDataType
+    data_format: Optional[AttributeDataFormat]
+    is_required: bool = False
+    is_relation: bool = False
+
+
+class ShareV2SchemaRelation(NamedTuple):
+    name: str
+    relation_shape: RelationShape
+    related_concrete_type: str
+    inverse_relation: str
+    is_required: bool = False
+    is_implicit: bool = False
+    is_relation: bool = True

--- a/tests/share/schema/test_schema.py
+++ b/tests/share/schema/test_schema.py
@@ -1,0 +1,234 @@
+import pytest
+
+from share.schema import ShareV2Schema
+from share.schema.shapes import AttributeDataType, AttributeDataFormat, RelationShape
+from share.schema.shapes import ShareV2SchemaType, ShareV2SchemaAttribute, ShareV2SchemaRelation
+
+WORK_TYPES = {
+    'creativework',
+    'dataset',
+    'patent',
+    'poster',
+    'publication',
+    'article',
+    'book',
+    'conferencepaper',
+    'dissertation',
+    'preprint',
+    'project',
+    'registration',
+    'report',
+    'thesis',
+    'workingpaper',
+    'presentation',
+    'repository',
+    'retraction',
+    'software',
+}
+
+EXPLICIT_WORK_FIELDS = {
+    'title',
+    'description',
+    'is_deleted',
+    'date_published',
+    'date_updated',
+    'free_to_read_type',
+    'free_to_read_date',
+    'rights',
+    'language',
+    'registration_type',
+    'withdrawn',
+    'justification',
+    'extra',
+    'subjects',
+    'tags',
+    'related_agents',
+    'related_works',
+    'identifiers',
+}
+
+AGENT_TYPES = {
+    'agent',
+    'organization',
+    'consortium',
+    'department',
+    'institution',
+    'person',
+}
+
+EXPLICIT_AGENT_FIELDS = {
+    'name',
+    'location',
+    'family_name',
+    'given_name',
+    'additional_name',
+    'suffix',
+    'extra',
+    'related_agents',
+    'identifiers',
+    'related_works',
+}
+
+
+class TestStaticSchema:
+    @pytest.fixture(scope='class')
+    def schema(self):
+        return ShareV2Schema()
+
+    @pytest.mark.parametrize('type_name, expected', [
+        ('registration', ShareV2SchemaType(
+            'registration',
+            'abstractcreativework',
+            EXPLICIT_WORK_FIELDS,
+            3,
+        )),
+        ('publication', ShareV2SchemaType(
+            'publication',
+            'abstractcreativework',
+            EXPLICIT_WORK_FIELDS,
+            2,
+        )),
+        ('creativework', ShareV2SchemaType(
+            'creativework',
+            'abstractcreativework',
+            EXPLICIT_WORK_FIELDS,
+            1,
+        )),
+        ('consortium', ShareV2SchemaType(
+            'consortium',
+            'abstractagent',
+            EXPLICIT_AGENT_FIELDS,
+            3,
+        )),
+        ('person', ShareV2SchemaType(
+            'person',
+            'abstractagent',
+            EXPLICIT_AGENT_FIELDS,
+            2,
+        )),
+        ('agent', ShareV2SchemaType(
+            'agent',
+            'abstractagent',
+            EXPLICIT_AGENT_FIELDS,
+            1,
+        )),
+    ])
+    def test_get_type(self, schema, type_name, expected):
+        actual = schema.get_type(type_name)
+        assert actual == expected
+
+    @pytest.mark.parametrize('type_name', WORK_TYPES)
+    @pytest.mark.parametrize('field_name, expected', [
+        ('title', ShareV2SchemaAttribute(
+            'title',
+            data_type=AttributeDataType.STRING,
+            data_format=None,
+            is_required=False,
+        )),
+        ('free_to_read_type', ShareV2SchemaAttribute(
+            'free_to_read_type',
+            data_type=AttributeDataType.STRING,
+            data_format=AttributeDataFormat.URI,
+            is_required=False,
+        )),
+        ('extra', ShareV2SchemaAttribute(
+            'extra',
+            data_type=AttributeDataType.OBJECT,
+            data_format=None,
+            is_required=False,
+        )),
+        ('tags', ShareV2SchemaRelation(
+            'tags',
+            relation_shape=RelationShape.MANY_TO_MANY,
+            related_concrete_type='tag',
+            inverse_relation='creative_works',
+            is_required=False,
+            is_implicit=False,
+        )),
+        ('agent_relations', ShareV2SchemaRelation(
+            'agent_relations',
+            relation_shape=RelationShape.ONE_TO_MANY,
+            related_concrete_type='abstractagentworkrelation',
+            inverse_relation='creative_work',
+            is_required=False,
+            is_implicit=True,
+        )),
+    ])
+    def test_spot_check_work_fields(self, schema, type_name, field_name, expected):
+        actual = schema.get_field(type_name, field_name)
+        assert actual == expected
+
+    @pytest.mark.parametrize('type_name', AGENT_TYPES)
+    @pytest.mark.parametrize('field_name, expected', [
+        ('name', ShareV2SchemaAttribute(
+            'name',
+            data_type=AttributeDataType.STRING,
+            data_format=None,
+            is_required=False,
+        )),
+        ('suffix', ShareV2SchemaAttribute(
+            'suffix',
+            data_type=AttributeDataType.STRING,
+            data_format=None,
+            is_required=False,
+        )),
+        ('identifiers', ShareV2SchemaRelation(
+            'identifiers',
+            relation_shape=RelationShape.ONE_TO_MANY,
+            related_concrete_type='agentidentifier',
+            inverse_relation='agent',
+            is_required=False,
+            is_implicit=False,
+        )),
+        ('related_works', ShareV2SchemaRelation(
+            'related_works',
+            relation_shape=RelationShape.MANY_TO_MANY,
+            related_concrete_type='abstractcreativework',
+            inverse_relation='related_agents',
+            is_required=False,
+            is_implicit=False,
+        )),
+        ('work_relations', ShareV2SchemaRelation(
+            'work_relations',
+            relation_shape=RelationShape.ONE_TO_MANY,
+            related_concrete_type='abstractagentworkrelation',
+            inverse_relation='agent',
+            is_required=False,
+            is_implicit=True,
+        )),
+    ])
+    def test_spot_check_agent_fields(self, schema, type_name, field_name, expected):
+        actual = schema.get_field(type_name, field_name)
+        assert actual == expected
+
+    @pytest.mark.parametrize('concrete_type, expected_type_names', (
+        ('abstractcreativework', WORK_TYPES),
+        ('abstractagent', AGENT_TYPES),
+        ('tag', {'tag'}),
+        ('award', {'award'}),
+        ('throughtags', {'throughtags'}),
+        ('subject', {'subject'}),
+        ('throughsubjects', {'throughsubjects'}),
+        ('throughawards', {'throughawards'}),
+        ('award', {'award'}),
+    ))
+    def test_get_type_names(self, schema, concrete_type, expected_type_names):
+        type_names = schema.get_type_names(concrete_type)
+        assert set(type_names) == expected_type_names
+
+    @pytest.mark.parametrize('type_name, field_name', (
+        ('preprint', 'name'),
+        ('bad_type', 'bad_field'),
+    ))
+    def test_get_invalid_field(self, schema, type_name, field_name):
+        with pytest.raises(KeyError):
+            schema.get_field(type_name, field_name)
+
+    @pytest.mark.parametrize('type_name', (
+        'abstractcreativework',
+        'bad',
+        'abstractagent',
+    ))
+    def test_get_invalid_type(self, type_name, schema):
+        with pytest.raises(KeyError):
+            schema.get_type('bad')

--- a/tests/share/schema/test_schema.py
+++ b/tests/share/schema/test_schema.py
@@ -6,25 +6,25 @@ from share.schema.shapes import AttributeDataType, AttributeDataFormat, Relation
 from share.schema.shapes import ShareV2SchemaType, ShareV2SchemaAttribute, ShareV2SchemaRelation
 
 WORK_TYPES = {
-    'creativework',
-    'dataset',
-    'patent',
-    'poster',
-    'publication',
-    'article',
-    'book',
-    'conferencepaper',
-    'dissertation',
-    'preprint',
-    'project',
-    'registration',
-    'report',
-    'thesis',
-    'workingpaper',
-    'presentation',
-    'repository',
-    'retraction',
-    'software',
+    'CreativeWork',
+    'DataSet',
+    'Patent',
+    'Poster',
+    'Publication',
+    'Article',
+    'Book',
+    'ConferencePaper',
+    'Dissertation',
+    'Preprint',
+    'Project',
+    'Registration',
+    'Report',
+    'Thesis',
+    'WorkingPaper',
+    'Presentation',
+    'Repository',
+    'Retraction',
+    'Software',
 }
 
 EXPLICIT_WORK_FIELDS = {
@@ -45,16 +45,15 @@ EXPLICIT_WORK_FIELDS = {
     'tags',
     'related_agents',
     'related_works',
-    'identifiers',
 }
 
 AGENT_TYPES = {
-    'agent',
-    'organization',
-    'consortium',
-    'department',
-    'institution',
-    'person',
+    'Agent',
+    'Organization',
+    'Consortium',
+    'Department',
+    'Institution',
+    'Person',
 }
 
 EXPLICIT_AGENT_FIELDS = {
@@ -66,7 +65,6 @@ EXPLICIT_AGENT_FIELDS = {
     'suffix',
     'extra',
     'related_agents',
-    'identifiers',
     'related_works',
 }
 
@@ -78,38 +76,38 @@ class TestStaticSchema:
 
     @pytest.mark.parametrize('type_name, expected', [
         ('registration', ShareV2SchemaType(
-            'registration',
-            'abstractcreativework',
+            'Registration',
+            'AbstractCreativeWork',
             EXPLICIT_WORK_FIELDS,
             3,
         )),
         ('publication', ShareV2SchemaType(
-            'publication',
-            'abstractcreativework',
+            'Publication',
+            'AbstractCreativeWork',
             EXPLICIT_WORK_FIELDS,
             2,
         )),
         ('creativework', ShareV2SchemaType(
-            'creativework',
-            'abstractcreativework',
+            'CreativeWork',
+            'AbstractCreativeWork',
             EXPLICIT_WORK_FIELDS,
             1,
         )),
         ('consortium', ShareV2SchemaType(
-            'consortium',
-            'abstractagent',
+            'Consortium',
+            'AbstractAgent',
             EXPLICIT_AGENT_FIELDS,
             3,
         )),
         ('person', ShareV2SchemaType(
-            'person',
-            'abstractagent',
+            'Person',
+            'AbstractAgent',
             EXPLICIT_AGENT_FIELDS,
             2,
         )),
         ('agent', ShareV2SchemaType(
-            'agent',
-            'abstractagent',
+            'Agent',
+            'AbstractAgent',
             EXPLICIT_AGENT_FIELDS,
             1,
         )),
@@ -141,7 +139,8 @@ class TestStaticSchema:
         ('tags', ShareV2SchemaRelation(
             'tags',
             relation_shape=RelationShape.MANY_TO_MANY,
-            related_concrete_type='tag',
+            related_concrete_type='Tag',
+            through_concrete_type='ThroughTags',
             inverse_relation='creative_works',
             is_required=False,
             is_implicit=False,
@@ -149,7 +148,7 @@ class TestStaticSchema:
         ('agent_relations', ShareV2SchemaRelation(
             'agent_relations',
             relation_shape=RelationShape.ONE_TO_MANY,
-            related_concrete_type='abstractagentworkrelation',
+            related_concrete_type='AbstractAgentWorkRelation',
             inverse_relation='creative_work',
             is_required=False,
             is_implicit=True,
@@ -176,15 +175,16 @@ class TestStaticSchema:
         ('identifiers', ShareV2SchemaRelation(
             'identifiers',
             relation_shape=RelationShape.ONE_TO_MANY,
-            related_concrete_type='agentidentifier',
+            related_concrete_type='AgentIdentifier',
             inverse_relation='agent',
             is_required=False,
-            is_implicit=False,
+            is_implicit=True,
         )),
         ('related_works', ShareV2SchemaRelation(
             'related_works',
             relation_shape=RelationShape.MANY_TO_MANY,
-            related_concrete_type='abstractcreativework',
+            related_concrete_type='AbstractCreativeWork',
+            through_concrete_type='AbstractAgentWorkRelation',
             inverse_relation='related_agents',
             is_required=False,
             is_implicit=False,
@@ -192,7 +192,7 @@ class TestStaticSchema:
         ('work_relations', ShareV2SchemaRelation(
             'work_relations',
             relation_shape=RelationShape.ONE_TO_MANY,
-            related_concrete_type='abstractagentworkrelation',
+            related_concrete_type='AbstractAgentWorkRelation',
             inverse_relation='agent',
             is_required=False,
             is_implicit=True,
@@ -204,14 +204,15 @@ class TestStaticSchema:
 
     @pytest.mark.parametrize('concrete_type, expected_type_names', (
         ('abstractcreativework', WORK_TYPES),
+        ('ABSTRACTCREATIVEWORK', WORK_TYPES),
         ('abstractagent', AGENT_TYPES),
-        ('tag', {'tag'}),
-        ('award', {'award'}),
-        ('throughtags', {'throughtags'}),
-        ('subject', {'subject'}),
-        ('throughsubjects', {'throughsubjects'}),
-        ('throughawards', {'throughawards'}),
-        ('award', {'award'}),
+        ('tag', {'Tag'}),
+        ('award', {'Award'}),
+        ('throughtags', {'ThroughTags'}),
+        ('Subject', {'Subject'}),
+        ('throughsubjects', {'ThroughSubjects'}),
+        ('throuGHAWards', {'ThroughAwards'}),
+        ('award', {'Award'}),
     ))
     def test_get_type_names(self, schema, concrete_type, expected_type_names):
         type_names = schema.get_type_names(concrete_type)
@@ -227,6 +228,7 @@ class TestStaticSchema:
 
     @pytest.mark.parametrize('type_name', (
         'abstractcreativework',
+        'AbstractCreativeWork',
         'bad',
         'abstractagent',
     ))

--- a/tests/share/schema/test_schema.py
+++ b/tests/share/schema/test_schema.py
@@ -1,6 +1,7 @@
 import pytest
 
 from share.schema import ShareV2Schema
+from share.schema.exceptions import SchemaKeyError
 from share.schema.shapes import AttributeDataType, AttributeDataFormat, RelationShape
 from share.schema.shapes import ShareV2SchemaType, ShareV2SchemaAttribute, ShareV2SchemaRelation
 
@@ -221,7 +222,7 @@ class TestStaticSchema:
         ('bad_type', 'bad_field'),
     ))
     def test_get_invalid_field(self, schema, type_name, field_name):
-        with pytest.raises(KeyError):
+        with pytest.raises(SchemaKeyError):
             schema.get_field(type_name, field_name)
 
     @pytest.mark.parametrize('type_name', (
@@ -230,5 +231,5 @@ class TestStaticSchema:
         'abstractagent',
     ))
     def test_get_invalid_type(self, type_name, schema):
-        with pytest.raises(KeyError):
+        with pytest.raises(SchemaKeyError):
             schema.get_type('bad')

--- a/tests/share/schema/test_schema_loader.py
+++ b/tests/share/schema/test_schema_loader.py
@@ -1,0 +1,164 @@
+import pytest
+
+from share.schema.exceptions import SchemaLoadError
+from share.schema.loader import SchemaLoader
+from share.schema.shapes import (
+    ShareV2SchemaType,
+    ShareV2SchemaAttribute,
+    ShareV2SchemaRelation,
+    AttributeDataType,
+    RelationShape,
+)
+
+
+@pytest.mark.parametrize('bad_attribute', [
+    {},
+    {'name': 'foo'},
+    {'name': 'foo', 'data_type': 'bad_data_type'},
+    {'name': 'foo', 'data_type': 'string', 'data_format': 'bad_data_format'},
+])
+def test_bad_attributes(bad_attribute):
+    type_spec_list = [{
+        'concrete_type': 'cement',
+        'attributes': [bad_attribute],
+    }]
+    with pytest.raises(SchemaLoadError):
+        SchemaLoader(type_spec_list)
+
+
+@pytest.mark.parametrize('bad_relations', [
+    [{}],
+    [{'name': 'foo'}],
+    [{'name': 'foo', 'relation_shape': 'many_to_many'}],
+    [{'name': 'foo', 'relation_shape': 'many_to_many', 'related_concrete_type': 'bad_cement'}],
+    [
+        {'name': 'foo', 'relation_shape': 'many_to_many', 'related_concrete_type': 'cement', 'inverse_relation': 'bar'},
+        {'name': 'bar', 'relation_shape': 'one_to_many', 'related_concrete_type': 'cement', 'inverse_relation': 'foo'},
+    ],
+])
+def test_bad_relations(bad_relations):
+    type_spec_list = [{
+        'concrete_type': 'cement',
+        'relations': bad_relations,
+    }]
+    with pytest.raises(SchemaLoadError):
+        SchemaLoader(type_spec_list)
+
+
+conflictly_type_spec_list = [{
+    'concrete_type': 'cement',
+    'attributes': [
+        {'name': 'foo', 'data_type': 'string'},
+    ],
+    'relations': [
+        {'name': 'foo', 'relation_shape': 'many_to_many', 'related_concrete_type': 'cement', 'inverse_relation': 'bar'},
+    ]
+}]
+
+
+def test_conflicts():
+    with pytest.raises(SchemaLoadError):
+        SchemaLoader(conflictly_type_spec_list)
+
+
+class TestGoodSchema:
+    @pytest.fixture(scope='class')
+    def loader(self):
+        return SchemaLoader([{
+            'concrete_type': 'cement',
+            'attributes': [
+                {'name': 'ash', 'data_type': 'string'},
+            ],
+            'relations': [
+                {'name': 'foo', 'relation_shape': 'many_to_many', 'related_concrete_type': 'cement', 'inverse_relation': 'bar'},
+                {'name': 'bar', 'relation_shape': 'many_to_many', 'related_concrete_type': 'cement', 'inverse_relation': 'foo'},
+            ],
+        }, {
+            'concrete_type': 'asphalt',
+            'type_tree': {
+                'bitumen': {
+                    'dilbit': {},
+                },
+                'tarmac': None,
+            },
+            'attributes': [
+                {'name': 'gravel', 'data_type': 'integer'},
+            ],
+            'relations': [
+                {'name': 'cement', 'relation_shape': 'many_to_one', 'related_concrete_type': 'cement', 'inverse_relation': 'implicit_asphalts'},
+                {'name': 'cements', 'relation_shape': 'one_to_many', 'related_concrete_type': 'cement', 'inverse_relation': 'implicit_asphalt'},
+            ],
+        }])
+
+    def test_type_names(self, loader):
+        assert loader.concrete_types == {'cement', 'asphalt'}
+
+        # concrete type 'asphalt' has subtypes, so shouldn't be in schema_types
+        actual_type_names = set(loader.schema_types.keys())
+        assert actual_type_names == {'cement', 'bitumen', 'dilbit', 'tarmac'}
+
+    @pytest.mark.parametrize('type_name, expected', [
+        ('cement', ShareV2SchemaType('cement', 'cement', {'ash', 'foo', 'bar'})),
+        ('bitumen', ShareV2SchemaType('bitumen', 'asphalt', {'gravel', 'cement', 'cements'}, 1)),
+        ('dilbit', ShareV2SchemaType('dilbit', 'asphalt', {'gravel', 'cement', 'cements'}, 2)),
+        ('tarmac', ShareV2SchemaType('tarmac', 'asphalt', {'gravel', 'cement', 'cements'}, 1)),
+    ])
+    def test_schema_types(self, loader, type_name, expected):
+        actual = loader.schema_types[type_name]
+        assert actual == expected
+
+    @pytest.mark.parametrize('type_name, field_name, expected', [
+        ('cement', 'ash', ShareV2SchemaAttribute(
+            'ash',
+            data_type=AttributeDataType.STRING,
+            data_format=None,
+            is_required=False,
+        )),
+        ('cement', 'foo', ShareV2SchemaRelation(
+            'foo',
+            relation_shape=RelationShape.MANY_TO_MANY,
+            related_concrete_type='cement',
+            inverse_relation='bar',
+        )),
+        ('cement', 'bar', ShareV2SchemaRelation(
+            'bar',
+            relation_shape=RelationShape.MANY_TO_MANY,
+            related_concrete_type='cement',
+            inverse_relation='foo',
+        )),
+        ('cement', 'implicit_asphalt', ShareV2SchemaRelation(
+            'implicit_asphalt',
+            relation_shape=RelationShape.MANY_TO_ONE,
+            related_concrete_type='asphalt',
+            inverse_relation='cements',
+            is_implicit=True,
+        )),
+        ('cement', 'implicit_asphalts', ShareV2SchemaRelation(
+            'implicit_asphalts',
+            relation_shape=RelationShape.ONE_TO_MANY,
+            related_concrete_type='asphalt',
+            inverse_relation='cement',
+            is_implicit=True,
+        )),
+        ('asphalt', 'gravel', ShareV2SchemaAttribute(
+            'gravel',
+            data_type=AttributeDataType.INTEGER,
+            data_format=None,
+            is_required=False,
+        )),
+        ('asphalt', 'cement', ShareV2SchemaRelation(
+            'cement',
+            relation_shape=RelationShape.MANY_TO_ONE,
+            related_concrete_type='cement',
+            inverse_relation='implicit_asphalts',
+        )),
+        ('asphalt', 'cements', ShareV2SchemaRelation(
+            'cements',
+            relation_shape=RelationShape.ONE_TO_MANY,
+            related_concrete_type='cement',
+            inverse_relation='implicit_asphalt',
+        )),
+    ])
+    def test_schema_fields(self, loader, type_name, field_name, expected):
+        actual = loader.schema_fields[(type_name, field_name)]
+        assert actual == expected


### PR DESCRIPTION
## what
add a static definition of the SHAREv2 schema, so we can start trimming tangles around all the `ShareObject` models

- `share/schema/schema-spec.yaml` contains the barest info actually needed by other code (mostly `share.util.graph` and `share.models.validators`)
- `share.schema.shapes` defines how the schema info will be structured
- `share.schema.loader` loads that yaml file and puts it in those structured shapes
- `share.schema.ShareV2Schema` ties the above together -- this is what consumers will import and use

## deliberate deviations
things that are meaningfully different from the model-based SHAREv2 schema
- remove `ThroughContributors` (and `Contributor.contributed_through`) -- there are exactly `0` of these on production
- all fields are defined on the concrete type
  - some fields in the model-based schema are only valid for specific subtypes -- this loosens that constraint
  - this simplifies things but *could* allow some slightly weird-looking data through
  - affected fields:
    - on `AbstractAgent`:
      - `Person.given_name`
      - `Person.family_name`
      - `Person.additional_name`
      - `Person.suffix`
    - on `AbstractCreativeWork`:
      - `Registration.registration_type`
      - `Registration.withdrawn`
      - `Registration.justification`
    - on `AbstractAgentWorkRelation`:
      - `Creator.order_cited`
      - `Funder.awards`

## TODO
- [x] basic tests (¿is the schema "correct"?)
  - [x] creative works
  - [x] agents
  - [x] tags/subjects
  - [x] relations
- [x] SchemaLoader unit tests

jira: [ENG-1984]

[ENG-1984]: https://openscience.atlassian.net/browse/ENG-1984