### PR TITLE
[ENG-1985] use share.schema in share.util.graph

### DIFF
--- a/share/disambiguation/matcher.py
+++ b/share/disambiguation/matcher.py
@@ -1,3 +1,5 @@
+from django.apps import apps
+
 from share.exceptions import MergeRequired
 from share.util import TopologicalSorter, ensure_iterable
 
@@ -41,7 +43,8 @@ class Matcher:
     def _group_nodes_by_model(self, graph):
         nodes_by_model = {}
         for node in graph:
-            nodes_by_model.setdefault(node.model, []).append(node)
+            model = apps.get_model('share', node.type)
+            nodes_by_model.setdefault(model, []).append(node)
 
         models = list(nodes_by_model.keys())
 

--- a/share/disambiguation/strategies/graph.py
+++ b/share/disambiguation/strategies/graph.py
@@ -71,9 +71,13 @@ class GraphStrategy(MatchingStrategy):
 
     def _graph_nodes(self, model, allowed_models=None):
         if allowed_models is None:
-            return self.graph.filter_by_concrete_model(model._meta.concrete_model)
+            return self.graph.filter_by_concrete_type(model._meta.concrete_model._meta.model_name)
         else:
+            allowed_model_names = {
+                allowed_model._meta.model_name.lower()
+                for allowed_model in allowed_models
+            }
             return filter(
-                lambda n: n.model in allowed_models,
+                lambda n: n.type in allowed_model_names,
                 self.graph,
             )

--- a/share/ingest/change_builder.py
+++ b/share/ingest/change_builder.py
@@ -63,7 +63,7 @@ class ChangeBuilder:
             logger.debug('No changes detected in {!r}, skipping.'.format(self.node))
             return None
 
-        model = self.node.model
+        model = apps.get_model('share', self.node.type)
 
         attrs = {
             'node_id': self.node.id,
@@ -89,10 +89,11 @@ class ChangeBuilder:
         return change
 
     def should_skip(self):
-        if not hasattr(self.node.model, 'VersionModel'):
+        model = apps.get_model('share', self.node.type)
+        if not hasattr(model, 'VersionModel'):
             # Non-ShareObjects (e.g. SubjectTaxonomy) cannot be changed.
             # Shouldn't reach this point...
-            logger.warn('Change node {!r} targets immutable model {}, skipping.'.format(self.node, self.node.model))
+            logger.warn('Change node {!r} targets immutable model {}, skipping.'.format(self.node, model))
             return True
 
         if self.instance:
@@ -145,7 +146,7 @@ class ChangeBuilder:
 
         ignore_attrs = self._get_ignore_attrs(attrs)
 
-        new_model = self.node.model
+        new_model = apps.get_model('share', self.node.type)
         old_model = type(self.instance)
         is_subject = new_model is apps.get_model('share', 'subject')
 
@@ -214,7 +215,8 @@ class ChangeBuilder:
     def _get_ignore_attrs(self, attrs):
         ignore_attrs = set()
 
-        if not issubclass(self.node.model, apps.get_model('share', 'creativework')):
+        model = apps.get_model('share', self.node.type)
+        if not issubclass(model, apps.get_model('share', 'creativework')):
             # Only work records get special treatment at the moment
             return ignore_attrs
 

--- a/share/regulate/steps/__init__.py
+++ b/share/regulate/steps/__init__.py
@@ -50,8 +50,7 @@ class NodeStep(BaseStep):
         """
         if self.node_types is None:
             return True
-        return (node.type.lower() in self.node_types
-                or node.model._meta.concrete_model._meta.model_name.lower() in self.node_types)
+        return (node.type in self.node_types or node.concrete_type in self.node_types)
 
     @abc.abstractmethod
     def regulate_node(self, node):

--- a/tests/share/util/test_mutable_graph.py
+++ b/tests/share/util/test_mutable_graph.py
@@ -66,6 +66,7 @@ class TestMutableGraph:
         (work_id, 'title', 'title title'),
         (work_id, 'description', 'woo'),
         (identifier_id, 'creative_work', None),
+        (identifier_id, 'foo', 'bar'),
     ])
     def test_set_attrs(self, mutable_graph, node_id, key, value):
         n = mutable_graph.get_node(node_id)


### PR DESCRIPTION
### what
refactor `MutableGraph` and `MutableNode` in `share.util.graph` to get schema info from `share.schema` (new in #776) instead of from the `ShareObject` model classes (which will soon be deleted)

### deviations
breaking changes in the public interface of `MutableGraph` and `MutableNode`:
- remove `MutableNode.model`, `MutableNode.concrete_model`
  - instead, use the new `MutableNode.schema_type` to get type info in the form `share.schema.shapes::ShareV2SchemaType`
- remove `MutableGraph.filter_by_concrete_model`
  - instead, use the new `MutableGraph.filter_by_concrete_type`, which takes a string instead of a model class


### jira
[ENG-1985]

[ENG-1985]: https://openscience.atlassian.net/browse/ENG-1985