### PR TITLE
[ENG-1986] use share.schema in share.models.validators

### DIFF
--- a/share/models/validators.py
+++ b/share/models/validators.py
@@ -2,18 +2,17 @@ import os
 import json
 import ujson
 from collections import OrderedDict
+from itertools import chain
 
 from jsonschema import exceptions
 from jsonschema import Draft4Validator, draft4_format_checker
 
-from typedmodels.models import TypedModel
-
-from django.db import connection
-from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
 
-from share.models.fields import ShareURLField
+from share.schema import ShareV2Schema
+from share.schema.exceptions import SchemaKeyError
+from share.schema.shapes import AttributeDataType, AttributeDataFormat, RelationShape
 from share.transform.chain.links import IRILink
 from share.transform.chain.exceptions import InvalidIRI
 
@@ -30,11 +29,11 @@ class JSONLDValidator:
         jsonld_schema = Draft4Validator(ujson.load(fobj))
 
     db_type_map = {
-        'text': 'string',
-        'boolean': 'boolean',
-        'integer': 'integer',
-        'varchar(254)': 'string',
-        'timestamp with time zone': 'string',
+        AttributeDataType.STRING: 'string',
+        AttributeDataType.BOOLEAN: 'boolean',
+        AttributeDataType.INTEGER: 'integer',
+        AttributeDataType.DATETIME: 'string',
+        AttributeDataType.OBJECT: 'object',
     }
 
     def __init__(self, check_existence=True):
@@ -68,13 +67,12 @@ class JSONLDValidator:
         return self.__check_existence == other.__check_existence
 
     def validate_node(self, value, refs, nodes):
-        model = apps.app_configs['share'].models.get(value['@type'].lower())
-
-        # concrete model is not valid for typed models
-        if model is None or (issubclass(model, TypedModel) and model._meta.concrete_model is model):
+        try:
+            schema_type = ShareV2Schema().get_type(value['@type'])
+        except SchemaKeyError:
             raise ValidationError("'{}' is not a valid type".format(value['@type']))
 
-        self.validator_for(model).validate(value)
+        self.validator_for(schema_type).validate(value)
 
         for key, val in value.items():
             if not isinstance(val, dict) or key == 'extra':
@@ -90,86 +88,68 @@ class JSONLDValidator:
         else:
             nodes['concrete'].add((value['@id'], value['@type'].lower()))
 
-    def json_schema_for_field(self, field):
-        if field.is_relation:
-            if field.many_to_many:
-                model = field.remote_field.through._meta.concrete_model
+    def json_schema_for_field(self, share_field):
+        if share_field.is_relation:
+            if share_field.relation_shape == RelationShape.MANY_TO_MANY:
+                concrete_type = share_field.through_concrete_type
             else:
-                model = field.related_model._meta.concrete_model
-
-            if issubclass(model, TypedModel) and model._meta.concrete_model is model:
-                allowed_models = model.get_type_classes()
-            else:
-                allowed_models = [model]
+                concrete_type = share_field.related_concrete_type
 
             rel = {
                 'type': 'object',
-                'description': getattr(field, 'description', ''),
+                'description': getattr(share_field, 'description', ''),
                 'required': ['@id', '@type'],
                 'additionalProperties': False,
                 'properties': {
                     '@id': {'type': ['string', 'integer']},
                     # Sorted so the same error message is sent back every time
-                    '@type': {'enum': sorted(sum([
-                        # Generate all acceptable variants of the class name
-                        # Class, CLASS, class
-                        [
-                            m.__name__,
-                            m.__name__.upper(),
-                            m.__name__.lower(),
-                        ] for m in allowed_models
-                    ], []))},
+                    '@type': {'enum': sorted(chain(*[
+                        # ideally would be case-insensitive, but jsonschema enums don't know how.
+                        # instead, allow 'FooBar', 'foobar', and 'FOOBAR' casings
+                        (type_name, type_name.lower(), type_name.upper())
+                        for type_name in ShareV2Schema().get_type_names(concrete_type)
+                    ]))}
                 }
             }
-            if field.many_to_many or field.one_to_many:
+            if share_field.relation_shape in (RelationShape.MANY_TO_MANY, RelationShape.ONE_TO_MANY):
                 return {'type': 'array', 'items': rel}
             return rel
-        if field.choices:
-            return {
-                'enum': [c[1] for c in field.choices],
-                'description': field.description
-            }
 
         schema = {
-            'type': JSONLDValidator.db_type_map[field.db_type(connection)],
-            'description': field.description
+            'type': JSONLDValidator.db_type_map[share_field.data_type],
+            'description': getattr(share_field, 'description', ''),
         }
-        if schema['type'] == 'string' and not field.blank:
-            schema['minLength'] = 1
-        if isinstance(field, ShareURLField):
+        if share_field.data_format == AttributeDataFormat.URI:
             schema['format'] = 'uri'
 
         return schema
 
-    def validator_for(self, model):
-        if model in JSONLDValidator.__schema_cache:
-            return JSONLDValidator.__schema_cache[model]
+    def validator_for(self, share_schema_type):
+        if share_schema_type.name in JSONLDValidator.__schema_cache:
+            return JSONLDValidator.__schema_cache[share_schema_type.name]
 
         schema = {
             'type': 'object',
             'required': ['@id', '@type'],
             'additionalProperties': False,
             'properties': {
-                'extra': {'type': 'object'},
                 '@type': {'type': 'string'},
                 '@id': {'type': ['integer', 'string']},
             }
         }
 
-        for field in self.allowed_fields_for_model(model):
-            if not (field.null or field.blank or field.many_to_many or field.one_to_many or field.has_default()):
-                schema['required'].append(field.name)
-            schema['properties'][field.name] = self.json_schema_for_field(field)
+        share_schema = ShareV2Schema()
 
-        return JSONLDValidator.__schema_cache.setdefault(model, Draft4Validator(schema, format_checker=draft4_format_checker))
+        for field_name in share_schema_type.explicit_fields:
+            share_field = share_schema.get_field(share_schema_type.name, field_name)
+            if share_field.is_required:
+                schema['required'].append(share_field.name)
+            schema['properties'][share_field.name] = self.json_schema_for_field(share_field)
 
-    def allowed_fields_for_model(self, model):
-        excluded = {'id', 'type', 'sources', 'changes', 'same_as', 'extra'}
-        fields = model._meta.get_fields()
-        allowed_fields = [f for f in fields if f.editable and f.name not in excluded]
-        # Include one-to-many relations to models with no other relations
-        allowed_fields.extend(f for f in fields if f.one_to_many and f.name not in excluded and hasattr(f.related_model, 'VersionModel') and not [rf for rf in f.related_model._meta.get_fields() if rf.editable and rf.is_relation and rf.remote_field != f and rf.name not in excluded])
-        return allowed_fields
+        return JSONLDValidator.__schema_cache.setdefault(
+            share_schema_type.name,
+            Draft4Validator(schema, format_checker=draft4_format_checker),
+        )
 
 
 def is_valid_iri(iri):

--- a/tests/api/test_validator.py
+++ b/tests/api/test_validator.py
@@ -294,18 +294,11 @@ class TestValidator:
     }, {
         'out': Response(400, json={
             'errors': [{
-                'detail': "Additional properties are not allowed ('family_name' was unexpected) at /@graph/0",
+                'detail': "Additional properties are not allowed ('publishers' was unexpected) at /@graph/2",
                 'source': {'pointer': '/data/attributes/data'},
                 'status': '400'
             }]
         }),
-        'in': requests.Request('POST', json=valid_work_invalid_agent_field)
-    }, {
-        'out': Response(400, json={'errors': [{
-            'detail': "Additional properties are not allowed ('family_name' was unexpected) at /@graph/0",
-            'source': {'pointer': '/data/attributes/data'},
-            'status': '400'
-        }]}),
         'in': requests.Request('POST', json=valid_work_invalid_agent_field)
     }, {
         # does not break because the raw information is not processed


### PR DESCRIPTION
### what
trim another important dependency on the ShareObject family -- refactor `JSONLDValidator` in `share.models.validators` to get schema info from `share.schema` (new in #776) instead of from the `ShareObject` model classes (which will soon be deleted)

### deviations
because `share.schema` has all fields defined on the concrete type (see #776), validation is now slightly looser in some cases -- attributes previously only valid for one subtype (e.g. `Person.given_name`) are now valid for all subtypes of that concrete type (e.g. `Organization`, `Institution`, `Consortium`, `Department`, and `Agent` may now also have a `given_name`)

i admit this is a little weird, but it probably will not matter.

### jira
[ENG-1986]

[ENG-1986]: https://openscience.atlassian.net/browse/ENG-1986