### PR TITLE
[ENG-2482] add format_metadata_records management command

### DIFF
--- a/api/normalizeddata/views.py
+++ b/api/normalizeddata/views.py
@@ -78,7 +78,10 @@ class NormalizedDataViewSet(ShareViewSet, generics.ListCreateAPIView, generics.R
 
         with transaction.atomic():
             # Hack for back-compat: Ingest halfway synchronously, then apply changes asynchronously
-            ingester = Ingester(data, suid).as_user(request.user).ingest(apply_changes=False)
+            ingester = Ingester(data, suid).as_user(request.user).ingest(
+                apply_changes=False,
+                pls_format_metadata=False,
+            )
             ingester.job.reschedule(claim=True)
 
             nd_id = models.NormalizedData.objects.filter(

--- a/share/janitor/tasks.py
+++ b/share/janitor/tasks.py
@@ -47,7 +47,7 @@ def rawdata_janitor(self, limit=500):
     for rd in qs[:limit]:
         count += 1
         logger.debug('Found unprocessed %r from %r', rd, rd.suid.source_config)
-        job = IngestScheduler().schedule(rd.suid, rd.id)
+        job = IngestScheduler().schedule(rd.suid)
         logger.info('Created job %s for %s', job, rd)
     if count:
         logger.warning('Found %d total unprocessed RawData', count)

--- a/share/management/commands/format_metadata_records.py
+++ b/share/management/commands/format_metadata_records.py
@@ -1,0 +1,54 @@
+from django.db import connection
+
+from share.management.commands import BaseShareCommand
+from share.models.jobs import IngestJob
+from share.tasks import ingest
+from share.util.extensions import Extensions
+
+
+# get most recent job.id for each suid
+# TODO clean up significantly once ingest jobs and suids are one-to-one
+ingest_job_sql = '''
+SELECT DISTINCT ON (job.suid_id) job.id, job.suid_id
+FROM share_ingestjob AS job
+WHERE job.suid_id >= %(suid_start_id)s
+ORDER BY job.suid_id ASC, job.date_started DESC NULLS LAST, job.date_created DESC
+'''
+
+
+class Command(BaseShareCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('metadata_formats', nargs='*', help='metadata format name (see entry points in setup.py)')
+        parser.add_argument('--suid-start-id', '-s', type=int, default=0, help='metadata format name (see entry points in setup.py)')
+
+    def handle(self, *args, **options):
+        metadata_formats = options['metadata_formats']
+        suid_start_id = options['suid_start_id']
+        valid_formats = Extensions.get_names('share.metadata_formats')
+        if not metadata_formats:
+            self.stdout.write(f'Valid metadata formats: {metadata_formats}')
+            return
+        if any(mf not in valid_formats for mf in metadata_formats):
+            invalid_formats = set(metadata_formats).difference(valid_formats)
+            self.stderr.write(f'Invalid metadata format(s): {invalid_formats}. Valid formats: {valid_formats}')
+            return
+
+        # giving the cursor a name makes it a server-side cursor
+        with connection._cursor(name='most_recent_job_per_suid') as cursor:
+            cursor.execute(ingest_job_sql, {'suid_start_id': suid_start_id})
+            while True:
+                result_rows = cursor.fetchmany(size=2000)
+                if not result_rows:
+                    self.stdout.write('all done!')
+                    break
+                last_suid_id = result_rows[-1][1]
+                job_ids = [result_row[0] for result_row in result_rows]
+                IngestJob.objects.filter(id__in=job_ids).update(status=IngestJob.STATUS.created)
+                for job_id in job_ids:
+                    ingest.delay(
+                        job_id=job_id,
+                        apply_changes=False,  # skip the whole ShareObject mess
+                        pls_format_metadata=True,
+                        metadata_formats=metadata_formats,
+                    )
+                self.stdout.write(f'queued tasks for {len(job_ids)} IngestJobs (last suid: {last_suid_id})...')

--- a/share/models/ingest.py
+++ b/share/models/ingest.py
@@ -10,6 +10,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django.db import connection
 from django.db import connections
 from django.db import models
+from django.db.models.functions import Coalesce
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.deconstruct import deconstructible
@@ -262,6 +263,23 @@ class SourceUniqueIdentifier(models.Model):
 
     class Meta:
         unique_together = ('identifier', 'source_config')
+
+    @property
+    def ingest_job(self):
+        """fetch the most recent IngestJob for this suid
+
+        (hopefully) temporary -- will be replaced by the inverse relation of a OneToOneField on IngestJob
+        """
+        return self.ingest_jobs.order_by(
+            Coalesce('date_started', 'date_created').desc(nulls_last=True)
+        ).first()
+
+    def most_recent_raw_datum(self):
+        """fetch the most recent RawDatum for this suid
+        """
+        return self.raw_data.order_by(
+            Coalesce('datestamp', 'date_created').desc(nulls_last=True)
+        ).first()
 
     def __repr__(self):
         return '<{}({}, {}, {!r})>'.format('Suid', self.id, self.source_config.label, self.identifier)

--- a/share/search/daemon.py
+++ b/share/search/daemon.py
@@ -235,7 +235,7 @@ class IncomingMessageLoop:
                     continue
 
         if messages_by_id:
-            raise DaemonIndexingError(f'Action generator skipped some target_ids! {messages_by_id}')
+            raise DaemonIndexingError(f'Action generator skipped some target_ids! \n\ttarget_id_chunk:{target_id_chunk}\n\tleftover messages:{messages_by_id}')
 
         logger.info('%sPrepared %d docs to be indexed in %.02fs', self.log_prefix, success_count, time.time() - start)
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -131,7 +131,15 @@ class RawDatumFactory(DjangoModelFactory):
         if 'sha256' not in attrs:
             attrs['sha256'] = hashlib.sha256(attrs.get('datum', '').encode()).hexdigest()
 
-        return super()._generate(create, attrs)
+        raw_datum = super()._generate(create, attrs)
+
+        # HACK: allow overriding auto_now_add on date_created
+        date_created = attrs.pop('date_created', None)
+        if date_created is not None:
+            raw_datum.date_created = date_created
+            raw_datum.save()
+
+        return raw_datum
 
 
 class HarvestJobFactory(DjangoModelFactory):
@@ -163,6 +171,18 @@ class IngestJobFactory(DjangoModelFactory):
 
     class Meta:
         model = models.IngestJob
+
+    @classmethod
+    def _generate(cls, create, attrs):
+        ingest_job = super()._generate(create, attrs)
+
+        # HACK: allow overriding auto_now_add on date_created
+        date_created = attrs.pop('date_created', None)
+        if date_created is not None:
+            ingest_job.date_created = date_created
+            ingest_job.save()
+
+        return ingest_job
 
 
 class CeleryTaskResultFactory(DjangoModelFactory):

--- a/tests/share/models/test_suid.py
+++ b/tests/share/models/test_suid.py
@@ -1,0 +1,60 @@
+import pytest
+
+from tests.factories import (
+    IngestJobFactory,
+    RawDatumFactory,
+    SourceUniqueIdentifierFactory,
+)
+
+
+@pytest.mark.django_db
+class TestSourceUniqueIdentifier:
+
+    def test_most_recent_raw_datum(self):
+        suid = SourceUniqueIdentifierFactory()
+
+        RawDatumFactory(suid=suid, datestamp=None, date_created='2021-01-01 00:00Z')
+        expected = RawDatumFactory(suid=suid, datestamp='2021-01-04 00:00Z')
+        RawDatumFactory(suid=suid, datestamp='2021-01-01 00:00Z')
+        RawDatumFactory(suid=suid, datestamp='2021-01-02 00:00Z')
+        RawDatumFactory(suid=suid, datestamp='2021-01-03 00:00Z')
+
+        actual = suid.most_recent_raw_datum()
+        assert expected == actual
+
+    def test_most_recent_raw_datum__datestamp_wins(self):
+        suid = SourceUniqueIdentifierFactory()
+
+        RawDatumFactory(suid=suid, datestamp='2021-01-01 00:00Z', date_created='2021-01-02 00:00Z')
+        expected = RawDatumFactory(suid=suid, datestamp='2021-01-02 00:00Z', date_created='2021-01-01 00:00Z')
+
+        actual = suid.most_recent_raw_datum()
+        assert expected == actual
+
+    def test_most_recent_raw_datum_no_datestamps(self):
+        suid = SourceUniqueIdentifierFactory()
+
+        expected = RawDatumFactory(suid=suid, datestamp=None, date_created='2021-01-02 00:00Z')
+        RawDatumFactory(suid=suid, datestamp=None, date_created='2021-01-01 00:00Z')
+
+        actual = suid.most_recent_raw_datum()
+        assert expected == actual
+
+    def test_ingest_job(self):
+        suid = SourceUniqueIdentifierFactory()
+
+        IngestJobFactory(suid=suid, date_started=None, date_created='2021-01-01 00:00Z')
+        expected = IngestJobFactory(suid=suid, date_started='2021-01-02 00:00Z', date_created='2021-01-01 00:00Z')
+        IngestJobFactory(suid=suid, date_started='2021-01-01 00:00Z', date_created='2021-01-01 00:00Z')
+
+        actual = suid.ingest_job
+        assert expected == actual
+
+    def test_ingest_job__date_started_wins(self):
+        suid = SourceUniqueIdentifierFactory()
+
+        expected = IngestJobFactory(suid=suid, date_started='2021-01-02 00:00Z', date_created='2021-01-01 00:00Z')
+        IngestJobFactory(suid=suid, date_started='2021-01-01 00:00Z', date_created='2021-01-03 00:00Z')
+
+        actual = suid.ingest_job
+        assert expected == actual

--- a/tests/share/tasks/test_ingest.py
+++ b/tests/share/tasks/test_ingest.py
@@ -1,6 +1,5 @@
 import json
 
-import pendulum
 import pytest
 
 from share.tasks import ingest
@@ -9,16 +8,6 @@ from tests import factories
 
 @pytest.mark.django_db
 class TestIngestJobConsumer:
-    def test_pointless(self):
-        job = factories.IngestJobFactory(raw__datestamp=pendulum.now().subtract(hours=2))
-        factories.IngestJobFactory(suid=job.suid, raw__datestamp=pendulum.now().subtract(hours=1))
-
-        ingest(job_id=job.id)
-
-        job.refresh_from_db()
-        assert job.status == job.STATUS.skipped
-        assert job.error_context == job.SkipReasons.pointless.value
-
     def test_no_output(self):
         raw = factories.RawDatumFactory(datum=json.dumps({
             '@graph': []


### PR DESCRIPTION
add a `format_metadata_records` management command meant to be used when we add a new metadata format -- queues non-urgent ingest tasks for *all* suids that will generate FormattedMetadataRecords in the given format(s)

side effects:
- update ingestion logic to kinda pretend that ingest jobs and suids are already one-to-one -- always use the most recent RawDatum for the job's suid
- add `SourceUniqueIdentifier.ingest_job` to get most recent ingest job for a suid (will someday soon be replaced with a proper OneToOneField)
- add `SourceUniqueIdentifier.most_recent_raw_datum()`
- add ingest task params:
  - `pls_format_metadata`: whether or not to follow the "new" FormattedMetadataRecord ingestion path (the "old" ShareObject path is controlled by the `apply_changes` param)
  - `metadata_formats`: which formats to create FMRs for (so running `format_metadata_records` won't do unnecessary, redundant work)