### PR TITLE
dock docs

### DIFF
--- a/README-docker-quickstart.md
+++ b/README-docker-quickstart.md
@@ -63,7 +63,18 @@ docker-compose up -d rabbitmq worker web indexer frontend
 
 ## handy commands
 
+### start a docker shell
+
+this is the same command you ran in step 2:
+
+```
+docker-compose run --rm --no-deps worker bash
+```
+
 ### start a django shell
+
+this should be run inside the docker shell (see previous):
+
 ```
 python manage.py shell_plus
 ```
@@ -84,14 +95,22 @@ for now, maybe grab a day of data from arxiv.org? at the moment, the `Source` ne
     Source.objects.filter(name='org.arxiv').update(canonical=True)
     ```
 
-then choose a recent date and start a harvest task for it:
+you will also need to update the subject index from the docker shell:
+
+```
+python manage.py addsubjects
+```
+
+next choose a recent date, and start a harvest task for it from the docker shell:
+
 ```
 sharectl schedule -t org.arxiv YYYY-MM-DD
 ```
+
 you could watch its progress several different ways:
   - looking at task queues in the rabbitmq management interface at http://localhost:15673/ (guest/guest)
   - following the `worker` container's logs: `docker-compose logs -f worker`
-  - watching the result count rise as you refresh the search interface at http://localhost:4203/discover
+  - watching the result count rise as you refresh the search interface at http://localhost:8003/share/discover
 
 ## troubleshooting
 - does docker have enough memory? try giving it more

--- a/README-docker-quickstart.md
+++ b/README-docker-quickstart.md
@@ -1,0 +1,97 @@
+# SHARE Quickstart or: How I Learned to Stop Worrying and Love the Dock
+
+this guide sets up everything inside docker containers -- no dependencies
+or python environments on your host machine.
+
+## pre-requisites
+- [git](https://git-scm.com/)
+- [docker](https://www.docker.com/) (including `docker-compose`)
+
+## getting a local SHARE running
+
+### 0. git the code
+```
+git clone https://github.com/CenterForOpenScience/SHARE.git share
+```
+the rest of this guide assumes your working directory is the SHARE repository root
+(where the `docker-compose.yml` is):
+```
+cd ./share
+```
+
+### 1. download several bits
+download docker images (depending on your internet connection, this may take a beat):
+```
+docker-compose pull
+```
+install python dependencies (in a shared docker volume):
+```
+docker-compose up requirements
+```
+
+### 2. structured data
+there are two services that store persistent data: `postgres` and `elasticsearch`
+
+let's start them from the host machine:
+```
+docker-compose up -d postgres elasticsearch
+```
+
+since we're not installing anything more on the host machine, it'll be useful to open
+a shell running within SHARE's environment in docker:
+```
+docker-compose run --rm --no-deps worker bash
+```
+this will open a bash prompt within a temporary `worker` container -- from here we can
+use SHARE's python environment, including django's `manage.py` and SHARE's own `sharectl`
+utility (defined in `share/bin/`)
+
+from the worker shell, use django's `migrate` command to set up tables in postgres:
+```
+python manage.py migrate
+```
+and use `sharectl` to set up indexes in elasticsearch:
+```
+sharectl search setup --initial
+```
+
+### 3. start 'em up
+all other services can now be started (from the host machine):
+```
+docker-compose up -d rabbitmq worker web indexer frontend
+```
+
+## handy commands
+
+### start a django shell
+```
+python manage.py shell_plus
+```
+
+## admin interface
+http://localhost:8003/admin -- (admin/password)
+
+## harvesting data
+TODO: once share.osf.io/oaipmh is reliable, make it easy to init a local deployment by harvesting data from there
+
+also TODO: put some thought into unconvoluting the whole harvest-scheduling, ingest-disabling system
+
+for now, maybe grab a day of data from arxiv.org? at the moment, the `Source` needs to be marked
+`canonical` for the system to ingest its data -- either:
+  - update it in the admin interface: http://localhost:8003/admin/share/source/
+  - update it from the django shell:
+    ```
+    Source.objects.filter(name='org.arxiv').update(canonical=True)
+    ```
+
+then choose a recent date and start a harvest task for it:
+```
+sharectl schedule -t org.arxiv YYYY-MM-DD
+```
+you could watch its progress several different ways:
+  - looking at task queues in the rabbitmq management interface at http://localhost:15673/ (guest/guest)
+  - following the `worker` container's logs: `docker-compose logs -f worker`
+  - watching the result count rise as you refresh the search interface at http://localhost:4203/discover
+
+## troubleshooting
+- does docker have enough memory? try giving it more

--- a/README-docker-quickstart.md
+++ b/README-docker-quickstart.md
@@ -109,7 +109,9 @@ sharectl schedule -t org.arxiv YYYY-MM-DD
 you could watch its progress several different ways:
   - looking at task queues in the rabbitmq management interface at http://localhost:15673/ (guest/guest)
   - following the `worker` container's logs: `docker-compose logs -f worker`
-  - watching the result count rise as you refresh the search interface at http://localhost:8003/share/discover
+  - checking the result count as you refresh the search interface at http://localhost:8003/share/discover
+  - watching `IngestJob` statuses update in the admin at http://localhost:8003/admin/share/ingestjob/ (admin/password)
+    - useful for debugging! if ingest fails, the `IngestJob` will contain the error type, message, and stack trace
 
 ## troubleshooting
 - my containers keep mysteriously dying!

--- a/README-docker-quickstart.md
+++ b/README-docker-quickstart.md
@@ -54,6 +54,11 @@ and use `sharectl` to set up indexes in elasticsearch:
 ```
 sharectl search setup --initial
 ```
+you will also need to initialize the "central taxonomy" of subjects:
+
+```
+python manage.py addsubjects
+```
 
 ### 3. start 'em up
 all other services can now be started (from the host machine):
@@ -95,13 +100,7 @@ for now, maybe grab a day of data from arxiv.org? at the moment, the `Source` ne
     Source.objects.filter(name='org.arxiv').update(canonical=True)
     ```
 
-you will also need to update the subject index from the docker shell:
-
-```
-python manage.py addsubjects
-```
-
-next choose a recent date, and start a harvest task for it from the docker shell:
+next, choose a recent date, and start a harvest task for it from the docker shell:
 
 ```
 sharectl schedule -t org.arxiv YYYY-MM-DD

--- a/README-docker-quickstart.md
+++ b/README-docker-quickstart.md
@@ -46,7 +46,7 @@ this will open a bash prompt within a temporary `worker` container -- from here 
 use SHARE's python environment, including django's `manage.py` and SHARE's own `sharectl`
 utility (defined in `share/bin/`)
 
-from the worker shell, use django's `migrate` command to set up tables in postgres:
+from the docker shell, use django's `migrate` command to set up tables in postgres:
 ```
 python manage.py migrate
 ```
@@ -83,9 +83,9 @@ python manage.py shell_plus
 http://localhost:8003/admin -- (admin/password)
 
 ## harvesting data
-TODO: once share.osf.io/oaipmh is reliable, make it easy to init a local deployment by harvesting data from there
+> TODO: once share.osf.io/oaipmh is reliable, make it easy to init a local deployment by harvesting data from there
 
-also TODO: put some thought into unconvoluting the whole harvest-scheduling, ingest-disabling system
+> also TODO: put some thought into unconvoluting the whole harvest-scheduling, ingest-disabling system
 
 for now, maybe grab a day of data from arxiv.org? at the moment, the `Source` needs to be marked
 `canonical` for the system to ingest its data -- either:
@@ -113,4 +113,5 @@ you could watch its progress several different ways:
   - watching the result count rise as you refresh the search interface at http://localhost:8003/share/discover
 
 ## troubleshooting
-- does docker have enough memory? try giving it more
+- my containers keep mysteriously dying!
+  - does docker have enough memory? try giving it more

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,8 @@ services:
       - pip install -r requirements.txt -r dev-requirements.txt &&
         (python3 -m compileall /usr/local/lib/python3.6 || true) &&
         rm -Rf /python3.6/* &&
-        cp -Rf -p /usr/local/lib/python3.6 /
+        cp -Rf -p /usr/local/lib/python3.6 / &&
+        python3 setup.py develop
     restart: 'no'
     volumes:
       - ./:/code:cached

--- a/project/settings.py
+++ b/project/settings.py
@@ -308,7 +308,7 @@ ELASTICSEARCH = {
         'no_ack': False,  # WHY KOMBU THAT'S NOT HOW ENGLISH WORKS
     },
     # NOTE: "active" indexes will receive new records from the indexer daemon -- be sure they're set up first
-    'ACTIVE_INDEXES': split(os.environ.get('ELASTICSEARCH_ACTIVE_INDEXES', 'share_customtax_1'), ','),
+    'ACTIVE_INDEXES': split(os.environ.get('ELASTICSEARCH_ACTIVE_INDEXES', 'share_postrend_backcompat'), ','),
     # NOTE: indexes here won't be created automatically -- run `sharectl search setup <index_name>` BEFORE the daemon starts
     'INDEXES': {
         'share_v3': {
@@ -541,6 +541,7 @@ SUBJECTS_CENTRAL_TAXONOMY = os.environ.get('SUBJECTS_CENTRAL_TAXONOMY', 'bepress
 SUBJECTS_YAML = 'share/subjects.yaml'
 SUBJECT_SYNONYMS_JSON = 'share/models/synonyms.json'
 
+# if false, will skip disambiguation, building ChangeSets, and updating ShareObjects
 SHARE_LEGACY_PIPELINE = os.environ.get('SHARE_LEGACY_PIPELINE', True)
 
 HIDE_DEPRECATED_VIEWS = strtobool(os.environ.get('HIDE_DEPRECATED_VIEWS', 'False'))

--- a/share/bin/search.py
+++ b/share/bin/search.py
@@ -29,20 +29,33 @@ def search(args, argv):
 @search.subcommand('Drop the Elasticsearch index')
 def purge(args, argv):
     """
-    Usage: {0} search purge [options]
-
-    Options:
-        -i, --index=INDEX    The name of the Elasticsearch index to use.
+    Usage: {0} search purge <index_names>...
     """
-    ElasticManager().delete_index(args.get('--index'))
+    for index_name in args['<index_names>']:
+        ElasticManager().delete_index(index_name)
 
 
 @search.subcommand('Create indicies and apply mappings')
 def setup(args, argv):
     """
     Usage: {0} search setup <index_name>
+           {0} search setup --initial
     """
-    ElasticManager().create_index(args['<index_name>'])
+    is_initial = args.get('--initial')
+
+    if is_initial:
+        index_names = settings.ELASTICSEARCH['ACTIVE_INDEXES']
+    else:
+        index_names = [args['<index_name>']]
+
+    elastic_manager = ElasticManager()
+    for index_name in index_names:
+        print(f'creating elasticsearch index "{index_name}"...')
+        elastic_manager.create_index(index_name)
+
+    if is_initial:
+        primary_index = index_names[0]
+        elastic_manager.update_primary_alias(primary_index)
 
 
 @search.subcommand('Start the search indexing daemon')

--- a/share/management/commands/addsubjects.py
+++ b/share/management/commands/addsubjects.py
@@ -32,4 +32,4 @@ class Command(BaseCommand):
             } for s in subjects
         ]
 
-        Ingester(subjects).as_user(user).ingest()
+        Ingester(subjects, 'share/management/commands/addsubjects.py').as_user(user).ingest()

--- a/share/tasks/jobs.py
+++ b/share/tasks/jobs.py
@@ -332,7 +332,7 @@ class IngestJobConsumer(JobConsumer):
                 self._queue_for_indexing(job.suid, urgent)
 
         # soon-to-be-rended ShareObject-based process:
-        if apply_changes:
+        if settings.SHARE_LEGACY_PIPELINE and apply_changes:
             if graph is None:
                 graph = MutableGraph.from_jsonld(datum.data)
             updated_work_ids = self._apply_changes(job, graph, datum)


### PR DESCRIPTION
- add a bonus README with docker-only quickstart instructions
- some other changes to enable starting quick
  - run `setup.py develop` when installing requirements
  - give `ElasticManager` the ability to update the elasticsearch alias pointing to the primary search index
  - add `--initial` flag to `sharectl search setup` -- sets up all active indexes and the primary alias
