### PR TITLE
[ENG-2650] give the frontend enough to display something useful for each suid

### DIFF
--- a/api/banners/urls.py
+++ b/api/banners/urls.py
@@ -3,5 +3,5 @@ from api.banners import views
 
 
 router = SimpleRouter()
-router.register(r'site_banners', views.SiteBannerViewSet, base_name='site_banners')
+router.register(r'^site_?banners', views.SiteBannerViewSet, base_name='site_banners')
 urlpatterns = router.urls

--- a/api/formattedmetadatarecords/serializers.py
+++ b/api/formattedmetadatarecords/serializers.py
@@ -1,0 +1,19 @@
+from share import models
+
+from api.base import ShareSerializer
+from api.fields import ShareIdentityField
+
+
+class FormattedMetadataRecordSerializer(ShareSerializer):
+    # link to self
+    url = ShareIdentityField(view_name='api:formattedmetadatarecord-detail')
+
+    class Meta:
+        model = models.FormattedMetadataRecord
+        fields = (
+            'suid',
+            'record_format',
+            'date_modified',
+            'formatted_metadata',
+            'url',
+        )

--- a/api/formattedmetadatarecords/urls.py
+++ b/api/formattedmetadatarecords/urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import SimpleRouter
+from api.formattedmetadatarecords import views
+
+
+router = SimpleRouter()
+router.register(r'formattedmetadatarecords', views.FormattedMetadataRecordViewSet, base_name='formattedmetadatarecord')
+urlpatterns = router.urls

--- a/api/formattedmetadatarecords/views.py
+++ b/api/formattedmetadatarecords/views.py
@@ -1,0 +1,15 @@
+from rest_framework import viewsets
+
+from api.formattedmetadatarecords.serializers import FormattedMetadataRecordSerializer
+from api.base import ShareViewSet
+
+from share.models import FormattedMetadataRecord
+
+
+class FormattedMetadataRecordViewSet(ShareViewSet, viewsets.ReadOnlyModelViewSet):
+    serializer_class = FormattedMetadataRecordSerializer
+
+    ordering = ('id', )
+
+    def get_queryset(self):
+        return FormattedMetadataRecord.objects.all()

--- a/api/normalizeddata/views.py
+++ b/api/normalizeddata/views.py
@@ -1,3 +1,4 @@
+import logging
 from django.db import transaction
 from django.urls import reverse
 
@@ -18,6 +19,9 @@ from api.normalizeddata.serializers import BasicNormalizedDataSerializer
 from api.normalizeddata.serializers import FullNormalizedDataSerializer
 from api.pagination import CursorPagination
 from api.permissions import ReadOnlyOrTokenHasScopeOrIsAuthenticated
+
+
+logger = logging.getLogger(__name__)
 
 
 class NormalizedDataViewSet(ShareViewSet, generics.ListCreateAPIView, generics.RetrieveAPIView):

--- a/api/sourceconfigs/serializers.py
+++ b/api/sourceconfigs/serializers.py
@@ -3,8 +3,11 @@ from share import models
 from api.base import ShareSerializer
 
 
-# TODO make an endpoint for SourceConfigs
 class SourceConfigSerializer(ShareSerializer):
     class Meta:
         model = models.SourceConfig
-        fields = ('label',)
+        fields = (
+            'label',
+            'source',
+            'disabled',
+        )

--- a/api/sourceconfigs/urls.py
+++ b/api/sourceconfigs/urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import SimpleRouter
+from api.sourceconfigs import views
+
+
+router = SimpleRouter()
+router.register(r'sourceconfigs', views.SourceConfigViewSet, base_name='sourceconfig')
+urlpatterns = router.urls

--- a/api/sourceconfigs/views.py
+++ b/api/sourceconfigs/views.py
@@ -1,0 +1,15 @@
+from rest_framework import viewsets
+
+from api.sourceconfigs.serializers import SourceConfigSerializer
+from api.base import ShareViewSet
+
+from share.models import SourceConfig
+
+
+class SourceConfigViewSet(ShareViewSet, viewsets.ReadOnlyModelViewSet):
+    serializer_class = SourceConfigSerializer
+
+    ordering = ('id', )
+
+    def get_queryset(self):
+        return SourceConfig.objects.all()

--- a/api/sources/serializers.py
+++ b/api/sources/serializers.py
@@ -25,7 +25,14 @@ class ReadonlySourceSerializer(ShareSerializer):
 
     class Meta:
         model = models.Source
-        fields = ('name', 'home_page', 'long_title', 'icon', 'url')
+        fields = (
+            'name',
+            'home_page',
+            'long_title',
+            'icon',
+            'url',
+            'source_configs',
+        )
         read_only_fields = fields
 
 

--- a/api/suids/serializers.py
+++ b/api/suids/serializers.py
@@ -1,0 +1,25 @@
+from share import models
+
+from api.base import ShareSerializer
+from api.fields import ShareIdentityField
+from api.sourceconfigs.serializers import SourceConfigSerializer
+from api.formattedmetadatarecords.serializers import FormattedMetadataRecordSerializer
+
+
+class SuidSerializer(ShareSerializer):
+    included_serializers = {
+        'source_config': SourceConfigSerializer,
+        'formattedmetadatarecord_set': FormattedMetadataRecordSerializer,
+    }
+
+    # link to self
+    url = ShareIdentityField(view_name='api:suid-detail')
+
+    class Meta:
+        model = models.SourceUniqueIdentifier
+        fields = (
+            'identifier',
+            'source_config',
+            'url',
+            'formattedmetadatarecord_set',
+        )

--- a/api/suids/urls.py
+++ b/api/suids/urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import SimpleRouter
+from api.suids import views
+
+
+router = SimpleRouter()
+router.register(r'suids', views.SuidViewSet, base_name='suid')
+urlpatterns = router.urls

--- a/api/suids/views.py
+++ b/api/suids/views.py
@@ -1,0 +1,15 @@
+from rest_framework import viewsets
+
+from api.suids.serializers import SuidSerializer
+from api.base import ShareViewSet
+
+from share.models import SourceUniqueIdentifier
+
+
+class SuidViewSet(ShareViewSet, viewsets.ReadOnlyModelViewSet):
+    serializer_class = SuidSerializer
+
+    ordering = ('id', )
+
+    def get_queryset(self):
+        return SourceUniqueIdentifier.objects.all()

--- a/api/urls.py
+++ b/api/urls.py
@@ -12,12 +12,15 @@ app_name = 'api'
 urlpatterns = [
     url('^$', RootView.as_view()),
     url('^', include('api.banners.urls')),
+    url('^', include('api.formattedmetadatarecords.urls')),
     url('^', include('api.ingestjobs.urls')),
     url('^', include('api.normalizeddata.urls')),
     url('^', include('api.rawdata.urls')),
     url('^', include('api.shareobjects.urls')),
     url('^', include('api.sourceregistrations.urls')),
+    url('^', include('api.sourceconfigs.urls')),
     url('^', include('api.sources.urls')),
+    url('^', include('api.suids.urls')),
     url('^', include('api.users.urls')),
 
     url('^schemas?/', include('api.schemas.urls'), name='schema'),

--- a/share/models/core.py
+++ b/share/models/core.py
@@ -255,6 +255,9 @@ class FormattedMetadataRecord(models.Model):
     date_modified = models.DateTimeField(auto_now=True)
     formatted_metadata = models.TextField()  # could be JSON, XML, or whatever
 
+    class JSONAPIMeta(BaseJSONAPIMeta):
+        pass
+
     class Meta:
         unique_together = ('suid', 'record_format')
 

--- a/share/models/ingest.py
+++ b/share/models/ingest.py
@@ -261,6 +261,9 @@ class SourceUniqueIdentifier(models.Model):
     identifier = models.TextField()
     source_config = models.ForeignKey('SourceConfig', on_delete=models.CASCADE)
 
+    class JSONAPIMeta(BaseJSONAPIMeta):
+        pass
+
     class Meta:
         unique_together = ('identifier', 'source_config')
 

--- a/share/models/validators.py
+++ b/share/models/validators.py
@@ -153,11 +153,9 @@ class JSONLDValidator:
 
 
 def is_valid_iri(iri):
-    try:
-        IRILink().execute(iri)
-    except InvalidIRI:
-        return False
+    # raises InvalidIRI if invalid
+    IRILink().execute(iri)
     return True
 
 
-draft4_format_checker.checks('uri', raises=ValueError)(is_valid_iri)
+draft4_format_checker.checks('uri', raises=InvalidIRI)(is_valid_iri)


### PR DESCRIPTION
- expose some models in the api:
  - `/api/v2/formattedmetadatarecords/`
  - `/api/v2/sourceconfigs/`
  - `/api/v2/suids/`
- make the api a little more consistent (for ease of frontend changes)
- handle `localhost:port` urls in DEBUG mode (for ease of local testing)

blocks CenterForOpenScience/ember-share#216