### PR TITLE
[fix] upgrade/downgrade for compatibile dependencies

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']  # TODO: 3.12
-        postgres-version: ['10', '11', '12', '13', '14', '15']
+        python-version: ['3.10', '3.11']  # TODO: 3.12
+        postgres-version: ['10', '15']
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as app
+FROM python:3.10-slim as app
 
 RUN apt-get update \
     && apt-get install -y \

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -1,53 +1,9 @@
-from io import StringIO
-import cProfile
-import pstats
-
 from django.conf import settings
 from django.http import HttpResponse
 
 import sentry_sdk
 
 from api.deprecation import get_view_func_deprecation_level, DeprecationLevel
-
-
-# Adapted from http://www.djangosnippets.org/snippets/186/
-# Original author: udfalkso
-# Modified by: Shwagroo Team and Gun.io
-# Modified by: COS
-class ProfileMiddleware:
-    """
-    Displays hotshot profiling for any view.
-    http://yoursite.com/yourview/?prof
-    Add the "prof" key to query string by appending ?prof (or &prof=)
-    and you'll see the profiling results in your browser.
-    It's set up to only be available in django's debug mode, is available for superuser otherwise,
-    but you really shouldn't add this middleware to any production configuration.
-    """
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        if not ((settings.DEBUG or request.user.is_superuser) and 'prof' in request.GET):
-            return self.get_response(request)
-
-        request.GET._mutable = True
-        request.GET.pop('prof')
-        request.GET._mutable = False
-
-        prof = cProfile.Profile()
-        prof.enable()
-
-        response = self.get_response(request)
-
-        prof.disable()
-
-        s = StringIO()
-        ps = pstats.Stats(prof, stream=s).sort_stats('cumtime')
-        ps.print_stats()
-
-        response.content = s.getvalue()
-
-        return response
 
 
 class DeprecationMiddleware:

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -1,14 +1,14 @@
 from xml.sax.saxutils import unescape
-from furl import furl
 import json
 import logging
-import pendulum
 
 from django.contrib.syndication.views import Feed
 from django.http import HttpResponseGone
 from django.utils.feedgenerator import Atom1Feed
 from django.conf import settings
-from raven.contrib.django.raven_compat.models import client as sentry_client
+from furl import furl
+import pendulum
+import sentry_sdk
 
 from share.search import IndexStrategy
 from share.search.exceptions import IndexStrategyError
@@ -69,7 +69,7 @@ class MetadataRecordsRSS(Feed):
                 request_body=obj,
             )
         except IndexStrategyError:
-            sentry_client.captureException()
+            sentry_sdk.capture_exception()
             return
 
         def get_item(hit):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,15 +147,15 @@ services:
       - apt-get update &&
         apt-get install -y gcc &&
         pip install -r requirements.txt -r dev-requirements.txt &&
-        (python3 -m compileall /usr/local/lib/python3.11 || true) &&
-        rm -Rf /python3.11/* &&
+        (python3 -m compileall /usr/local/lib/python3.10 || true) &&
+        rm -Rf /python3.10/* &&
         apt-get remove -y gcc &&
-        cp -Rf -p /usr/local/lib/python3.11 / &&
+        cp -Rf -p /usr/local/lib/python3.10 / &&
         python3 setup.py develop
     restart: 'no'
     volumes:
       - ./:/code:cached
-      - share_requirements_vol:/python3.11
+      - share_requirements_vol:/python3.10
 
   frontend:
     image: quay.io/centerforopenscience/share-web:develop-local
@@ -177,7 +177,7 @@ services:
       - indexer
     volumes:
       - ./:/code:cached
-      - share_requirements_vol:/usr/local/lib/python3.11
+      - share_requirements_vol:/usr/local/lib/python3.10
       - elastic8_cert_vol:/elastic8_certs
     env_file:
       - .docker-compose.env
@@ -198,7 +198,7 @@ services:
       - frontend
     volumes:
       - ./:/code:cached
-      - share_requirements_vol:/usr/local/lib/python3.11
+      - share_requirements_vol:/usr/local/lib/python3.10
       - elastic8_cert_vol:/elastic8_certs
     env_file:
       - .docker-compose.env
@@ -216,7 +216,7 @@ services:
       - elastic8
     volumes:
       - ./:/code:cached
-      - share_requirements_vol:/usr/local/lib/python3.11
+      - share_requirements_vol:/usr/local/lib/python3.10
       - elastic8_cert_vol:/elastic8_certs
     env_file:
       - .docker-compose.env

--- a/project/celery.py
+++ b/project/celery.py
@@ -2,28 +2,13 @@ import os
 
 import celery
 
-from raven.contrib.celery import register_signal, register_logger_signal
-
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
 
 from django.conf import settings  # noqa
 
 
-class Celery(celery.Celery):
-
-    def on_configure(self):
-        # Import has to be relative. "client" is not actually lazily initialized
-        from raven.contrib.django.raven_compat.models import client
-
-        if not client.is_enabled():
-            return
-
-        register_signal(client)
-        register_logger_signal(client)
-
-
-app = Celery('project')
+app = celery.Celery('project')
 
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks([

--- a/project/logging_formatter.py
+++ b/project/logging_formatter.py
@@ -1,0 +1,10 @@
+import json
+import logging
+
+
+class JsonLogFormatter(logging.Formatter):
+    def format(self, record):
+        return json.dumps({
+            'severity': record.levelname,
+            'message': record.__dict__,
+        })

--- a/project/settings.py
+++ b/project/settings.py
@@ -589,6 +589,3 @@ if DEBUG and os.environ.get('TOOLBAR', False):
         'SHOW_TOOLBAR_CALLBACK': lambda _: True
     }
     ALLOWED_HOSTS.append('localhost')
-
-if DEBUG and os.environ.get('PROF', False):
-    MIDDLEWARE += ('api.middleware.ProfileMiddleware', )

--- a/project/settings.py
+++ b/project/settings.py
@@ -457,7 +457,7 @@ CELERY_TASK_QUEUES = {
 
 
 # Logging
-LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()
+LOG_LEVEL = os.environ.get('LOG_LEVEL', default=('INFO' if DEBUG else 'WARNING')).upper()
 
 LOGGING = {
     'version': 1,
@@ -466,18 +466,21 @@ LOGGING = {
         'console': {
             '()': 'colorlog.ColoredFormatter',
             'format': '%(cyan)s[%(asctime)s]%(purple)s[%(threadName)s]%(log_color)s[%(levelname)s][%(name)s]: %(reset)s%(message)s'
-        }
+        },
+        'json': {
+            '()': 'project.logging_formatter.JsonLogFormatter',
+        },
     },
     'handlers': {
         'stream-to-stderr': {
             'class': 'logging.StreamHandler',
             'level': LOG_LEVEL,
-            'formatter': 'console',
+            'formatter': ('console' if DEBUG else 'json'),
         },
     },
     'loggers': {
         '': {
-            'level': ('DEBUG' if DEBUG else 'INFO'),
+            'level': LOG_LEVEL,
             'handlers': ['stream-to-stderr'],
             'propagate': False
         },

--- a/project/settings.py
+++ b/project/settings.py
@@ -57,6 +57,7 @@ SENSITIVE_DATA_KEY = jwe.kdf(SECRET_KEY.encode('utf-8'), SALT.encode('utf-8'))
 DEBUG = bool(os.environ.get('DEBUG', True))
 
 VERSION = __version__
+GIT_COMMIT = os.environ.get('GIT_COMMIT', None)
 
 ALLOWED_HOSTS = [h for h in os.environ.get('ALLOWED_HOSTS', '').split(' ') if h]
 
@@ -236,15 +237,29 @@ LOGIN_REDIRECT_URL = os.environ.get('LOGIN_REDIRECT_URL', 'http://localhost:8000
 
 if DEBUG:
     AUTH_PASSWORD_VALIDATORS = []
-# else:
+
 if os.environ.get('USE_SENTRY'):
-    INSTALLED_APPS += [
-        'raven.contrib.django.raven_compat',
-    ]
-    RAVEN_CONFIG = {
-        'dsn': os.environ.get('SENTRY_DSN', None),
-        'release': os.environ.get('GIT_COMMIT', None),
-    }
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+    sentry_sdk.init(
+        dsn=os.environ.get('SENTRY_DSN', None),
+        release=(
+            '-'.join((VERSION, GIT_COMMIT))
+            if GIT_COMMIT
+            else VERSION
+        ),
+        send_default_pii=False,
+        request_bodies=False,
+        debug=DEBUG,
+        integrations=[
+            DjangoIntegration(
+                transaction_style='endpoint',
+                middleware_spans=True,
+                signals_spans=True,
+                cache_spans=True,
+            ),
+        ],
+    )
 
 
 # TODO REMOVE BEFORE PRODUCTION
@@ -454,58 +469,24 @@ LOGGING = {
         }
     },
     'handlers': {
-        'sentry': {
-            'level': 'ERROR',  # To capture more than ERROR, change to WARNING, INFO, etc.
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-            'tags': {'custom-tag': 'x'},
-        },
-        'console': {
+        'stream-to-stderr': {
             'class': 'logging.StreamHandler',
-            'level': 'DEBUG',
-            'formatter': 'console'
+            'level': LOG_LEVEL,
+            'formatter': 'console',
         },
     },
     'loggers': {
         '': {
-            'handlers': ['console'],
-            'level': 'INFO',
-            'propagate': False
-        },
-        'bots': {
-            'handlers': ['console'],
-            'level': LOG_LEVEL,
-            'propagate': False
-        },
-        'elasticsearch': {
-            'handlers': ['console'],
-            'level': LOG_LEVEL,
-            'propagate': False
-        },
-        'share': {
-            'handlers': ['console'],
-            'level': LOG_LEVEL,
+            'level': ('DEBUG' if DEBUG else 'INFO'),
+            'handlers': ['stream-to-stderr'],
             'propagate': False
         },
         'django.db.backends': {
             'level': 'ERROR',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'raven': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'sentry.errors': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
+            'handlers': ['stream-to-stderr'],
             'propagate': False,
         },
     },
-    'root': {
-        'level': 'WARNING',
-        'handlers': ['sentry'],
-    }
 }
 
 # shell_plus convenience utilities

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,8 @@ psycopg2==2.9.5  # LGPL with exceptions or ZPL
 python-dateutil==2.8.1  # Apache 2.0
 PyJWE==1.0.0 # Apache 2.0
 pyyaml==6.0  # MIT
-raven==6.10.0  # BSD
 requests==2.25.1  # Apache 2.0
+sentry-sdk[django]==1.22.2  # MIT
 stevedore==3.3.0  # Apache 2.0
 xmltodict==0.12.0  # MIT
 

--- a/share/celery.py
+++ b/share/celery.py
@@ -10,7 +10,7 @@ from celery.utils.time import maybe_timedelta
 from django.db import transaction
 from django.utils import timezone
 
-from raven.contrib.django.raven_compat.models import client
+import sentry_sdk
 
 from share.util import chunked
 from share.models import CeleryTaskResult
@@ -29,8 +29,8 @@ def die_on_unhandled(func):
         except Exception as e:
             err = e
             try:
-                client.captureException()
                 logger.exception('Celery internal method %s failed', func)
+                sentry_sdk.capture_exception()
             finally:
                 if err:
                     raise SystemExit(57)  # Something a bit less generic than 1 or -1

--- a/share/search/index_messenger.py
+++ b/share/search/index_messenger.py
@@ -7,8 +7,8 @@ import celery
 from django.conf import settings
 import kombu
 import kombu.simple
-from raven.contrib.django.raven_compat.models import client as sentry_client
 import requests
+import sentry_sdk
 
 from share.search.messages import MessagesChunk, MessageType
 from share.search.index_strategy import IndexStrategy
@@ -72,7 +72,7 @@ class IndexMessenger:
             )
             return resp.json().get('messages', 0)
         except Exception:
-            sentry_client.captureException()
+            sentry_sdk.capture_exception()
             return '??'
 
     def send_message(self, message_type: MessageType, target_id, *, urgent=False):

--- a/tests/share/search/index_strategy/_with_real_services.py
+++ b/tests/share/search/index_strategy/_with_real_services.py
@@ -58,6 +58,12 @@ class RealElasticTestCase(TransactionTestCase):
         self.current_index.pls_delete()
         IndexStrategy.clear_strategy_cache()
 
+    def enterContext(self, context_manager):
+        # TestCase.enterContext added in python3.11 -- implementing here until then
+        result = context_manager.__enter__()
+        self.addCleanup(lambda: context_manager.__exit__(None, None, None))
+        return result
+
     @contextlib.contextmanager
     def _daemon_up(self):
         stop_event = IndexerDaemon.start_daemonthreads(

--- a/tests/share/search/test_daemon.py
+++ b/tests/share/search/test_daemon.py
@@ -125,7 +125,7 @@ class TestIndexerDaemon:
             def pls_handle_messages_chunk(self, messages_chunk):
                 raise UnexpectedError
 
-        with mock.patch('share.search.daemon.sentry_client') as mock_sentry:
+        with mock.patch('share.search.daemon.sentry_sdk') as mock_sentry:
             with mock.patch('share.search.daemon.logger') as mock_logger:
                 with _daemon_running(
                     FakeIndexStrategyWithUnexpectedError(),
@@ -136,7 +136,7 @@ class TestIndexerDaemon:
                     assert daemon.stop_event.wait(timeout=10), (
                         'daemon should have stopped after an unexpected error'
                     )
-                    mock_sentry.captureException.assert_called_once()
+                    mock_sentry.capture_exception.assert_called_once()
                     mock_logger.exception.assert_called_once()
 
     def test_noncurrent_backfill(self):
@@ -174,7 +174,7 @@ class TestIndexerDaemon:
                         error_text='i am a teapot',
                     )
 
-        with mock.patch('share.search.daemon.sentry_client') as mock_sentry:
+        with mock.patch('share.search.daemon.sentry_sdk') as mock_sentry:
             with mock.patch('share.search.daemon.logger') as mock_logger:
                 with _daemon_running(FakeIndexStrategyWithMessageError()) as daemon:
                     message = FakeCeleryMessage(messages.MessageType.INDEX_SUID, 1)
@@ -184,7 +184,7 @@ class TestIndexerDaemon:
                         'daemon should not have stopped for a message error'
                     )
                     # and logged
-                    mock_sentry.captureMessage.assert_called_once()
+                    mock_sentry.capture_message.assert_called_once()
                     mock_logger.error.assert_called_once()
                     # but the message acked
                     assert message.acked


### PR DESCRIPTION
- downgrade to python 3.10 (for now)
- upgrade to `sentry-sdk` (from `raven`)
- add log formatter to produce single-line json (when not in debug mode)
- tidy some code