### PR TITLE
[ENG-4657] add suggestedFilterOperator

### DIFF
--- a/share/search/search_params.py
+++ b/share/search/search_params.py
@@ -20,7 +20,8 @@ from trove.vocab.osfmap import (
     suggested_property_paths,
     OSFMAP_VOCAB,
 )
-from trove.vocab.namespaces import RDF
+from trove.vocab.trove import trove_labeler
+from trove.vocab.namespaces import RDF, TROVE
 
 
 logger = logging.getLogger(__name__)
@@ -143,14 +144,19 @@ class Textsegment:
 @dataclasses.dataclass(frozen=True)
 class SearchFilter:
     class FilterOperator(enum.Enum):
-        # TODO: use iris from TROVE IriNamespace
-        ANY_OF = 'any-of'
-        NONE_OF = 'none-of'
-        IS_PRESENT = 'is-present'
-        IS_ABSENT = 'is-absent'
-        BEFORE = 'before'
-        AFTER = 'after'
-        AT_DATE = 'at-date'
+        # iri values
+        ANY_OF = TROVE['any-of']
+        NONE_OF = TROVE['none-of']
+        IS_PRESENT = TROVE['is-present']
+        IS_ABSENT = TROVE['is-absent']
+        BEFORE = TROVE['before']
+        AFTER = TROVE['after']
+        AT_DATE = TROVE['at-date']
+
+        @classmethod
+        def from_shortname(cls, shortname):
+            _iri = trove_labeler.iri_for_label(shortname)
+            return cls(_iri)
 
         def is_date_operator(self):
             return self in (self.BEFORE, self.AFTER, self.AT_DATE)
@@ -191,7 +197,7 @@ class SearchFilter:
         else:  # given operator
             if _operator_value:
                 try:
-                    _operator = SearchFilter.FilterOperator(_operator_value)
+                    _operator = SearchFilter.FilterOperator.from_shortname(_operator_value)
                 except ValueError:
                     raise ValueError(f'unrecognized search-filter operator "{_operator_value}"')
         _propertypath = tuple(

--- a/trove/vocab/osfmap.py
+++ b/trove/vocab/osfmap.py
@@ -2,7 +2,18 @@ from gather import primitive_rdf, gathering
 
 from trove.util.iri_labeler import IriLabeler
 from trove.vocab.trove import JSONAPI_MEMBERNAME
-from trove.vocab.namespaces import OSFMAP, DCTERMS, FOAF, OWL, RDF, RDFS, SKOS, DCMITYPE, DCAT
+from trove.vocab.namespaces import (
+    DCAT,
+    DCMITYPE,
+    DCTERMS,
+    FOAF,
+    OSFMAP,
+    OWL,
+    RDF,
+    RDFS,
+    SKOS,
+    TROVE,
+)
 
 
 # TODO: define as turtle, load in trove.vocab.__init__?
@@ -770,6 +781,31 @@ AGENT_SUGGESTED_PROPERTY_PATHS = (
 )
 
 
+SUGGESTED_PRESENCE_PROPERTIES = frozenset((
+    OSFMAP.hasAnalyticCodeResource,
+    OSFMAP.hasDataResource,
+    OSFMAP.hasMaterialsResource,
+    OSFMAP.hasPapersResource,
+    OSFMAP.hasPreregisteredAnalysisPlan,
+    OSFMAP.hasPreregisteredStudyDesign,
+    OSFMAP.hasSupplementalResource,
+    OSFMAP.isSupplementedBy,
+    OSFMAP.supplements,
+))
+
+
+DATE_PROPERTIES = frozenset((
+    DCTERMS.date,
+    DCTERMS.available,
+    DCTERMS.created,
+    DCTERMS.modified,
+    DCTERMS.dateCopyrighted,
+    DCTERMS.dateSubmitted,
+    DCTERMS.dateAccepted,
+    OSFMAP.dateWithdrawn,
+))
+
+
 def suggested_property_paths(type_iris: set[str]) -> tuple[tuple[str, ...]]:
     if not type_iris or not type_iris.issubset(OSFMAP_NORMS.focustype_iris):
         return ()
@@ -786,15 +822,15 @@ def suggested_property_paths(type_iris: set[str]) -> tuple[tuple[str, ...]]:
     return ALL_SUGGESTED_PROPERTY_PATHS
 
 
+def suggested_filter_operator(property_iri: str):
+    # return iri value for the suggested trove-search filter operator
+    if is_date_property(property_iri):
+        return TROVE['at-date']
+    if property_iri in SUGGESTED_PRESENCE_PROPERTIES:
+        return TROVE['is-present']
+    return TROVE['any-of']
+
+
 def is_date_property(property_iri):
     # TODO: better inference (rdfs:range?)
-    return property_iri in {
-        DCTERMS.date,
-        DCTERMS.available,
-        DCTERMS.created,
-        DCTERMS.modified,
-        DCTERMS.dateCopyrighted,
-        DCTERMS.dateSubmitted,
-        DCTERMS.dateAccepted,
-        OSFMAP.dateWithdrawn,
-    }
+    return property_iri in DATE_PROPERTIES

--- a/trove/vocab/trove.py
+++ b/trove/vocab/trove.py
@@ -151,16 +151,16 @@ TROVE_API_VOCAB: primitive_rdf.RdfTripleDictionary = {
             primitive_rdf.text('filterValueSet', language_tag='en'),
         },
     },
-    TROVE.iriValue: {
-        RDF.type: {RDF.Property, OWL.FunctionalProperty, JSONAPI_ATTRIBUTE},
-        JSONAPI_MEMBERNAME: {
-            primitive_rdf.text('iriValue', language_tag='en'),
-        },
-    },
     TROVE.cardsearchResultCount: {
         RDF.type: {RDF.Property, OWL.FunctionalProperty, JSONAPI_ATTRIBUTE},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('cardSearchResultCount', language_tag='en'),
+        },
+    },
+    TROVE.suggestedFilterOperator: {
+        RDF.type: {RDF.Property, OWL.FunctionalProperty, JSONAPI_ATTRIBUTE},
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('suggestedFilterOperator', language_tag='en'),
         },
     },
 
@@ -192,33 +192,50 @@ TROVE_API_VOCAB: primitive_rdf.RdfTripleDictionary = {
 
     # values:
     TROVE['ten-thousands-and-more']: {
-        RDF.type: {RDF.Property},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('ten-thousands-and-more', language_tag='en'),
         },
     },
     TROVE['any-of']: {
-        RDF.type: {RDF.Property},
+        RDF.type: {TROVE.FilterOperator},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('any-of', language_tag='en'),
         },
     },
     TROVE['none-of']: {
-        RDF.type: {RDF.Property},
+        RDF.type: {TROVE.FilterOperator},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('none-of', language_tag='en'),
         },
     },
+    TROVE['is-absent']: {
+        RDF.type: {TROVE.FilterOperator},
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('is-absent', language_tag='en'),
+        },
+    },
+    TROVE['is-present']: {
+        RDF.type: {TROVE.FilterOperator},
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('is-present', language_tag='en'),
+        },
+    },
     TROVE.before: {
-        RDF.type: {RDF.Property},
+        RDF.type: {TROVE.FilterOperator},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('before', language_tag='en'),
         },
     },
     TROVE.after: {
-        RDF.type: {RDF.Property},
+        RDF.type: {TROVE.FilterOperator},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('after', language_tag='en'),
+        },
+    },
+    TROVE['at-date']: {
+        RDF.type: {TROVE.FilterOperator},
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('at-date', language_tag='en'),
         },
     },
 


### PR DESCRIPTION
each `related-property-path` included with an `index-card-search` response now comes with a `suggestedFilterOperator` attribute that could be used in another `index-card-search` request with the query param `cardSearchFilter[<propertyPathKey>][<suggestedFilterOperator>]`

e.g. the following suggests that adding `cardSearchFilter[supplements][is-present]` to the current search would yield 1 result
```js
    {
      "id": "...",
      "type": "related-property-path",
      "attributes": {
        "propertyPathKey": "supplements"
        "suggestedFilterOperator": "is-present",
        "cardSearchResultCount": 1,
        // ...
      }
    },
```

suggests `"at-date"` for date properties, `"is-present"` for "boolean filter facets", and `"any-of"` to recommend an `index-value-search` to find valid iri values to filter by

(ticket: [ENG-4657])

[ENG-4657]: https://openscience.atlassian.net/browse/ENG-4657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ