### PR TITLE
support filtering across multiple propertypaths

### DIFF
--- a/share/models/feature_flag.py
+++ b/share/models/feature_flag.py
@@ -29,6 +29,7 @@ class FeatureFlag(models.Model):
     # flag name constants:
     ELASTIC_EIGHT_DEFAULT = 'elastic_eight_default'
     IGNORE_SHAREV2_INGEST = 'ignore_sharev2_ingest'
+    PERIODIC_PROPERTYPATH = 'periodic_propertypath'
 
     # name _should_ be one of the constants above, but that is not enforced by `choices`
     name = models.TextField(unique=True)

--- a/tests/_testutil.py
+++ b/tests/_testutil.py
@@ -1,0 +1,12 @@
+from unittest import mock
+
+
+def patch_feature_flag(*flag_names, up=True):
+    from share.models.feature_flag import FeatureFlag
+    _old_isup = FeatureFlag.objects.flag_is_up
+
+    def _patched_isup(flag_name):
+        if flag_name in flag_names:
+            return up
+        return _old_isup(flag_name)
+    return mock.patch.object(FeatureFlag.objects, 'flag_is_up', new=_patched_isup)

--- a/trove/vocab/osfmap.py
+++ b/trove/vocab/osfmap.py
@@ -107,6 +107,15 @@ OSFMAP_VOCAB: primitive_rdf.RdfTripleDictionary = {
             primitive_rdf.text('rights', language_tag='en'),
         },
     },
+    DCTERMS.rightsHolder: {
+        RDF.type: {RDF.Property},
+        RDFS.label: {
+            primitive_rdf.text('License holder', language_tag='en'),
+        },
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('rightsHolder', language_tag='en'),
+        },
+    },
     DCTERMS.description: {
         RDF.type: {RDF.Property},
         RDFS.label: {
@@ -350,7 +359,7 @@ OSFMAP_VOCAB: primitive_rdf.RdfTripleDictionary = {
     OSFMAP.hasPapersResource: {
         RDF.type: {RDF.Property},
         RDFS.label: {
-            primitive_rdf.text('Papers resource', language_tag='en'),
+            primitive_rdf.text('Papers', language_tag='en'),
         },
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('hasPapersResource', language_tag='en'),

--- a/trove/vocab/trove.py
+++ b/trove/vocab/trove.py
@@ -121,22 +121,34 @@ TROVE_API_VOCAB: primitive_rdf.RdfTripleDictionary = {
             primitive_rdf.text('matchingHighlight', language_tag='en'),
         },
     },
-    TROVE.propertyPath: {
-        RDF.type: {RDF.Property, OWL.FunctionalProperty, JSONAPI_ATTRIBUTE},
-        JSONAPI_MEMBERNAME: {
-            primitive_rdf.text('propertyPath', language_tag='en'),
-        },
-    },
     TROVE.propertyPathKey: {
         RDF.type: {RDF.Property, OWL.FunctionalProperty, JSONAPI_ATTRIBUTE},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('propertyPathKey', language_tag='en'),
         },
     },
+    TROVE.propertyPath: {
+        RDF.type: {RDF.Property, OWL.FunctionalProperty, JSONAPI_ATTRIBUTE},
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('propertyPath', language_tag='en'),
+        },
+    },
     TROVE.osfmapPropertyPath: {
         RDF.type: {RDF.Property, OWL.FunctionalProperty, JSONAPI_ATTRIBUTE},
         JSONAPI_MEMBERNAME: {
             primitive_rdf.text('osfmapPropertyPath', language_tag='en'),
+        },
+    },
+    TROVE.propertyPathSet: {
+        RDF.type: {RDF.Property, JSONAPI_ATTRIBUTE},
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('propertyPathSet', language_tag='en'),
+        },
+    },
+    TROVE.osfmapPropertyPathSet: {
+        RDF.type: {RDF.Property, JSONAPI_ATTRIBUTE},
+        JSONAPI_MEMBERNAME: {
+            primitive_rdf.text('osfmapPropertyPathSet', language_tag='en'),
         },
     },
     TROVE.filterType: {


### PR DESCRIPTION
breaking change behind a feature flag (`periodic_propertypaths`)

change how property paths are serialized in query params:
- use `.` (period) to delimit path-steps, e.g. `creator.affiliation`
  parsed as one path of two steps (previously `creator,affiliation`)
- use `,` (comma) to delimit multiple paths, e.g.
  `creator.affiliation,contributor.affiliation` parsed as two paths of
  two steps (previously impossible)
