### PR TITLE
[ENG-6072] fix ci

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -173,6 +173,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'api.middleware.DeprecationMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
 ]
 
 INTERNAL_IPS = ['127.0.0.1']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 bcrypt==3.2.0  # Apache 2.0
 beautifulsoup4==4.9.3  # MIT
-celery==5.1.2  # BSD 3 Clause
+celery==5.4.0  # BSD 3 Clause
 colorlog==5.0.1  # MIT
-django-allauth==0.44.0  # MIT
+django-allauth==0.63.6  # MIT
 django-celery-beat==2.2.1  # BSD 3 Clause
 django-cors-headers==3.7.0  # MIT
 django-extensions==3.1.3  # MIT
@@ -20,7 +20,7 @@ furl==2.1.2  # None
 gevent==22.10.2  # MIT
 jsonschema==3.2.0  # MIT
 lxml==4.9.1  # BSD
-kombu==5.1.0  # BSD 3 Clause
+kombu==5.3.7  # BSD 3 Clause
 markdown2==2.4.10  # MIT
 nameparser==1.0.6  # LGPL
 networkx==2.5.1  # BSD
@@ -29,7 +29,7 @@ pendulum==2.1.2  # MIT
 pillow==9.3.0  # PIL Software License
 psycogreen==1.0.2  # BSD
 psycopg2==2.9.5  # LGPL with exceptions or ZPL
-python-dateutil==2.8.1  # Apache 2.0
+python-dateutil==2.9.0  # Apache 2.0
 PyJWE==1.0.0 # Apache 2.0
 rdflib==7.0.0
 pyyaml==6.0  # MIT


### PR DESCRIPTION
- bump celery to 5.4.0 (from 5.1.2)
- bump kombu to 5.3.7 (from 5.1.0)
- bump python-dateutil to 2.9.0 (from 2.8.1)
- bump django-allauth to 0.63.6 (from 0.44.0)