### PR TITLE
[ENG-5992] Add Subject facet to project search filters

### DIFF
--- a/trove/vocab/osfmap.py
+++ b/trove/vocab/osfmap.py
@@ -767,6 +767,7 @@ ALL_SUGGESTED_PROPERTY_PATHS = (
 PROJECT_SUGGESTED_PROPERTY_PATHS = (
     (DCTERMS.created,),
     (OSFMAP.funder,),
+    (DCTERMS.subject,),
     (DCTERMS.rights,),
     (DCTERMS.type,),
     (OSFMAP.affiliation,),


### PR DESCRIPTION
## Purpose

Enable search faceting for "Subject" on Projects

## Changes

- Added the (DCTERMS.subject,) field to the PROJECT_SUGGESTED_PROPERTY_PATHS in the osfmap.py file. 

## Ticket

[ENG-5992](https://openscience.atlassian.net/browse/ENG-5992)

[ENG-5992]: https://openscience.atlassian.net/browse/ENG-5992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ