### PR TITLE
[ENG-6189] denorm fixes/followup

### DIFF
--- a/share/search/index_strategy/_base.py
+++ b/share/search/index_strategy/_base.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 import logging
 import typing
 
@@ -63,8 +64,9 @@ class IndexStrategy(abc.ABC):
     def indexname_wildcard(self):
         return f'{self.indexname_prefix}*'
 
-    @property
+    @functools.cached_property
     def current_indexname(self):
+        self.assert_strategy_is_current()
         return ''.join((
             self.indexname_prefix,
             self.CURRENT_STRATEGY_CHECKSUM.hexdigest,

--- a/share/search/index_strategy/elastic8.py
+++ b/share/search/index_strategy/elastic8.py
@@ -69,7 +69,14 @@ class Elastic8IndexStrategy(IndexStrategy):
         messages_chunk: messages.MessagesChunk,
         indexnames: typing.Iterable[str],
     ) -> None:
-        pass  # implement when needed
+        ...  # implement when needed
+
+    def after_chunk(
+        self,
+        messages_chunk: messages.MessagesChunk,
+        indexnames: typing.Iterable[str],
+    ) -> None:
+        ...  # implement when needed
 
     ###
     # helper methods for subclasses to use (or override)
@@ -154,6 +161,7 @@ class Elastic8IndexStrategy(IndexStrategy):
                     status_code=_status,
                     error_text=str(_response_body),
                 )
+        self.after_chunk(messages_chunk, _indexnames)
         # yield successes after the whole chunk completes
         # (since one message may involve several actions)
         for _messageid in _action_tracker.all_done_messages():

--- a/share/search/index_strategy/trovesearch_denorm.py
+++ b/share/search/index_strategy/trovesearch_denorm.py
@@ -55,7 +55,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
     CURRENT_STRATEGY_CHECKSUM = ChecksumIri(
         checksumalgorithm_name='sha-256',
         salt='TrovesearchDenormIndexStrategy',
-        hexdigest='fa8fe6459f658877f84620412dcab5e2e70d0c949d8977354c586dca99ff2f28',
+        hexdigest='e538bbc5966a6a289da9e5ba51ecde5ff29528bf07e940716ef8a888d6601916',
     )
 
     # abstract method from IndexStrategy
@@ -83,6 +83,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
             'properties': {
                 'card': {'properties': self._card_mappings()},
                 'iri_value': {'properties': self._iri_value_mappings()},
+                'chunk_timestamp': {'type': 'unsigned_long'},
             },
         }
 
@@ -149,24 +150,24 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
         }
 
     # override method from Elastic8IndexStrategy
-    def before_chunk(self, messages_chunk: messages.MessagesChunk, indexnames: Iterable[str]):
-        # delete all per-value docs (to account for missing values)
+    def after_chunk(self, messages_chunk: messages.MessagesChunk, indexnames: Iterable[str]):
+        # refresh to avoid delete-by-query conflicts
+        self.es8_client.indices.refresh(index=','.join(indexnames))
+        # delete any docs that belong to cards in this chunk but weren't touched by indexing
         self.es8_client.delete_by_query(
             index=list(indexnames),
             query={'bool': {'must': [
                 {'terms': {'card.card_pk': messages_chunk.target_ids_chunk}},
-                {'exists': {'field': 'iri_value.value_iri'}},
+                {'range': {'chunk_timestamp': {'lt': messages_chunk.timestamp}}},
             ]}},
         )
-        # (possible optimization: instead, hold onto doc_ids and (in `after_chunk`?)
-        #                         delete_by_query excluding those)
 
     # abstract method from Elastic8IndexStrategy
     def build_elastic_actions(self, messages_chunk: messages.MessagesChunk):
         _indexcard_rdf_qs = ts.latest_rdf_for_indexcard_pks(messages_chunk.target_ids_chunk)
         _remaining_indexcard_pks = set(messages_chunk.target_ids_chunk)
         for _indexcard_rdf in _indexcard_rdf_qs:
-            _docbuilder = self._SourcedocBuilder(_indexcard_rdf)
+            _docbuilder = self._SourcedocBuilder(_indexcard_rdf, messages_chunk.timestamp)
             if not _docbuilder.should_skip():  # if skipped, will be deleted
                 _indexcard_pk = _indexcard_rdf.indexcard_id
                 for _doc_id, _doc in _docbuilder.build_docs():
@@ -254,6 +255,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
         '''build elasticsearch sourcedocs for an rdf document
         '''
         indexcard_rdf: trove_db.IndexcardRdf
+        chunk_timestamp: int
         indexcard: trove_db.Indexcard = dataclasses.field(init=False)
         focus_iri: str = dataclasses.field(init=False)
         rdfdoc: rdf.RdfTripleDictionary = dataclasses.field(init=False)
@@ -279,6 +281,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
                 yield self._doc_id(_iri), {
                     'card': self._card_subdoc,
                     'iri_value': self._iri_value_subdoc(_iri),
+                    'chunk_timestamp': self.chunk_timestamp,
                 }
 
         def _doc_id(self, value_iri=None) -> str:

--- a/share/search/index_strategy/trovesearch_denorm.py
+++ b/share/search/index_strategy/trovesearch_denorm.py
@@ -487,13 +487,12 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
                 PropertypathUsage(property_path=_path, usage_count=0)
                 for _path in cardsearch_params.related_property_paths
             )
-            _relatedproperty_by_path = {
-                _result.property_path: _result
+            _relatedproperty_by_pathkey = {
+                ts.propertypath_as_keyword(_result.property_path): _result
                 for _result in _relatedproperty_list
             }
             for _bucket in es8_response['aggregations']['agg_related_propertypath_usage']['buckets']:
-                _path = tuple(json.loads(_bucket['key']))
-                _relatedproperty_by_path[_path].usage_count += _bucket['doc_count']
+                _relatedproperty_by_pathkey[_bucket['key']].usage_count += _bucket['doc_count']
         return CardsearchResponse(
             cursor=cursor,
             search_result_page=_results,

--- a/share/search/messages.py
+++ b/share/search/messages.py
@@ -1,7 +1,9 @@
 import abc
 import dataclasses
 import enum
+import functools
 import logging
+import time
 import typing
 
 from share.search import exceptions
@@ -82,6 +84,10 @@ class MessagesChunk:
                 message_type=self.message_type,
                 target_id=target_id,
             )
+
+    @functools.cached_property  # cached so it's constant (and unique-enough) for an instance
+    def timestamp(self) -> int:
+        return time.time_ns()
 
     @classmethod
     def stream_chunks(

--- a/share/tasks/__init__.py
+++ b/share/tasks/__init__.py
@@ -79,14 +79,6 @@ def schedule_index_backfill(self, index_backfill_pk):
                 .exclude(source_config__source__is_deleted=True)
                 .values_list('id', flat=True)
             )
-        elif _messagetype == MessageType.BACKFILL_IDENTIFIER:
-            _targetid_queryset = (
-                trove_db.ResourceIdentifier.objects
-                .exclude(suid_set__source_config__disabled=True)
-                .exclude(suid_set__source_config__source__is_deleted=True)
-                .values_list('id', flat=True)
-                .distinct()
-            )
         else:
             raise ValueError(f'unknown backfill messagetype {_messagetype}')
         _chunk_size = settings.ELASTICSEARCH['CHUNK_SIZE']

--- a/tests/share/search/index_strategy/_common_trovesearch_tests.py
+++ b/tests/share/search/index_strategy/_common_trovesearch_tests.py
@@ -60,19 +60,54 @@ class CommonTrovesearchTests(RealElasticTestCase):
             self.cardsearch_cases(),
             self.cardsearch_integer_cases(),
         )
-        for _queryparams, _expected_result_iris in _cardsearch_cases:
-            _cardsearch_params = CardsearchParams.from_querystring(urlencode(_queryparams))
-            assert isinstance(_cardsearch_params, CardsearchParams)
-            _cardsearch_response = self.current_index.pls_handle_cardsearch(_cardsearch_params)
-            # assumes all results fit on one page
-            _actual_result_iris: set[str] | list[str] = [
-                self._indexcard_focus_by_uuid[_result.card_uuid]
-                for _result in _cardsearch_response.search_result_page
-            ]
-            # test sort order only when expected results are ordered
-            if isinstance(_expected_result_iris, set):
-                _actual_result_iris = set(_actual_result_iris)
-            self.assertEqual(_expected_result_iris, _actual_result_iris, msg=f'?{_queryparams}')
+        for _queryparams, _expected_focus_iris in _cardsearch_cases:
+            self._assert_cardsearch_iris(_queryparams, _expected_focus_iris)
+
+    def test_cardsearch_after_deletion(self):
+        _cards = self._fill_test_data_for_querying()
+        _deleted_focus_iris = {BLARG.b}
+        self._delete_indexcards([_cards[_focus_iri] for _focus_iri in _deleted_focus_iris])
+        _cardsearch_cases = itertools.chain(
+            self.cardsearch_cases(),
+            self.cardsearch_integer_cases(),
+        )
+        for _queryparams, _expected_focus_iris in _cardsearch_cases:
+            if isinstance(_expected_focus_iris, set):
+                _expected_focus_iris -= _deleted_focus_iris
+            else:
+                _expected_focus_iris = [
+                    _iri
+                    for _iri in _expected_focus_iris
+                    if _iri not in _deleted_focus_iris
+                ]
+            self._assert_cardsearch_iris(_queryparams, _expected_focus_iris)
+
+    def test_cardsearch_after_updates(self):
+        _cards = self._fill_test_data_for_querying()
+        self._update_indexcard_content(_cards[BLARG.c], BLARG.c, {
+            BLARG.c: {
+                RDF.type: {BLARG.Thing},
+                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_c},  # subj_bc removed; subj_c added
+                DCTERMS.title: {rdf.literal('cccc')},
+            },
+        })
+        self._index_indexcards([_cards[BLARG.c]])
+        _cases = [
+            (
+                {'cardSearchFilter[subject]': BLARG.subj_bc},
+                {BLARG.b},
+            ),
+            (
+                {'cardSearchFilter[subject]': BLARG.subj_ac},
+                {BLARG.c, BLARG.a},
+            ),
+            (
+                {'cardSearchFilter[subject]': BLARG.subj_c},
+                {BLARG.c},
+            ),
+        ]
+        for _queryparams, _expected_focus_iris in _cases:
+            self._assert_cardsearch_iris(_queryparams, _expected_focus_iris)
 
     def test_cardsearch_pagination(self):
         _cards: list[trove_db.Indexcard] = []
@@ -81,10 +116,10 @@ class CommonTrovesearchTests(RealElasticTestCase):
         _total_count = 55
         _start_date = date(1999, 12, 31)
         for _i in range(_total_count):
-            _card_iri = BLARG[f'i{_i}']
-            _expected_iris.add(_card_iri)
-            _cards.append(self._create_indexcard(_card_iri, {
-                _card_iri: {
+            _focus_iri = BLARG[f'i{_i}']
+            _expected_iris.add(_focus_iri)
+            _cards.append(self._create_indexcard(_focus_iri, {
+                _focus_iri: {
                     RDF.type: {BLARG.Thing},
                     DCTERMS.title: {rdf.literal(f'card #{_i}')},
                     DCTERMS.created: {rdf.literal(_start_date + timedelta(weeks=_i, days=_i))},
@@ -133,20 +168,80 @@ class CommonTrovesearchTests(RealElasticTestCase):
 
     def test_valuesearch(self):
         self._fill_test_data_for_querying()
-        _valuesearch_cases = itertools.chain(
-            self.valuesearch_simple_cases(),
-            self.valuesearch_complex_cases(),
-        )
-        for _queryparams, _expected_values in _valuesearch_cases:
-            _valuesearch_params = ValuesearchParams.from_querystring(urlencode(_queryparams))
-            assert isinstance(_valuesearch_params, ValuesearchParams)
-            _valuesearch_response = self.current_index.pls_handle_valuesearch(_valuesearch_params)
-            # assumes all results fit on one page
-            _actual_values = {
-                _result.value_iri or _result.value_value
-                for _result in _valuesearch_response.search_result_page
-            }
-            self.assertEqual(_expected_values, _actual_values)
+        for _queryparams, _expected_values in self.valuesearch_cases():
+            self._assert_valuesearch_values(_queryparams, _expected_values)
+
+    def test_valuesearch_after_deletion(self):
+        _cards = self._fill_test_data_for_querying()
+        _deleted_focus_iris = {BLARG.b}
+        self._delete_indexcards([_cards[_focus_iri] for _focus_iri in _deleted_focus_iris])
+        _cases = [
+            (
+                {'valueSearchPropertyPath': 'subject'},
+                {BLARG.subj_a, BLARG.subj_ac, BLARG.subj_bc, BLARG.subj_c},  # BLARG.subj_b no longer present
+            ), (
+                {'valueSearchPropertyPath': 'dateCreated'},
+                {'1999', '2024'},  # 2012 no longer present
+            ), (
+                {'valueSearchPropertyPath': 'subject', 'cardSearchText': 'bbbb'},
+                set(),  # none
+            )
+        ]
+        for _queryparams, _expected_values in _cases:
+            self._assert_valuesearch_values(_queryparams, _expected_values)
+
+    def test_valuesearch_after_updates(self):
+        _cards = self._fill_test_data_for_querying()
+        self._update_indexcard_content(_cards[BLARG.c], BLARG.c, {
+            BLARG.c: {
+                RDF.type: {BLARG.Thing},
+                DCTERMS.creator: {BLARG.someone_new},  # someone_else removed; someone_new added
+                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_c, BLARG.subj_new},  # subj_bc removed; subj_new added
+                DCTERMS.title: {rdf.literal('cccc')},
+            },
+        })
+        self._index_indexcards([_cards[BLARG.c]])
+        _cases = [
+            (
+                {'valueSearchPropertyPath': 'subject'},
+                {BLARG.subj_a, BLARG.subj_ac, BLARG.subj_b, BLARG.subj_bc, BLARG.subj_c, BLARG.subj_new},  # subj_c new
+            ), (
+                {'valueSearchPropertyPath': 'subject', 'cardSearchFilter[creator]': BLARG.someone_new},
+                {BLARG.subj_ac, BLARG.subj_c, BLARG.subj_new},
+            ), (
+                {'valueSearchPropertyPath': 'subject', 'cardSearchFilter[creator]': BLARG.someone_else},
+                set(),  # none
+            )
+        ]
+        for _queryparams, _expected_values in _cases:
+            self._assert_valuesearch_values(_queryparams, _expected_values)
+
+    def _assert_cardsearch_iris(self, queryparams: dict, expected_focus_iris: Iterable[str]):
+        _querystring = urlencode(queryparams)
+        _cardsearch_params = CardsearchParams.from_querystring(_querystring)
+        assert isinstance(_cardsearch_params, CardsearchParams)
+        _cardsearch_response = self.current_index.pls_handle_cardsearch(_cardsearch_params)
+        # assumes all results fit on one page
+        _actual_result_iris: set[str] | list[str] = [
+            self._indexcard_focus_by_uuid[_result.card_uuid]
+            for _result in _cardsearch_response.search_result_page
+        ]
+        # test sort order only when expected results are ordered
+        if isinstance(expected_focus_iris, set):
+            _actual_result_iris = set(_actual_result_iris)
+        self.assertEqual(expected_focus_iris, _actual_result_iris, msg=f'?{_querystring}')
+
+    def _assert_valuesearch_values(self, queryparams, expected_values):
+        _querystring = urlencode(queryparams)
+        _valuesearch_params = ValuesearchParams.from_querystring(_querystring)
+        assert isinstance(_valuesearch_params, ValuesearchParams)
+        _valuesearch_response = self.current_index.pls_handle_valuesearch(_valuesearch_params)
+        # assumes all results fit on one page
+        _actual_values = {
+            _result.value_iri or _result.value_value
+            for _result in _valuesearch_response.search_result_page
+        }
+        self.assertEqual(expected_values, _actual_values, msg=f'?{_querystring}')
 
     def _fill_test_data_for_querying(self):
         _card_a = self._create_indexcard(BLARG.a, {
@@ -171,7 +266,7 @@ class CommonTrovesearchTests(RealElasticTestCase):
             },
             BLARG.c: {
                 RDF.type: {BLARG.Thing},
-                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_bc},
+                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_bc, BLARG.subj_c},
                 DCTERMS.title: {rdf.literal('cccc')},
             },
         })
@@ -191,7 +286,7 @@ class CommonTrovesearchTests(RealElasticTestCase):
             },
             BLARG.c: {
                 RDF.type: {BLARG.Thing},
-                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_bc},
+                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_bc, BLARG.subj_c},
                 DCTERMS.title: {rdf.literal('cccc')},
             },
         })
@@ -201,7 +296,7 @@ class CommonTrovesearchTests(RealElasticTestCase):
                 DCTERMS.created: {rdf.literal(date(2024, 12, 31))},
                 DCTERMS.creator: {BLARG.someone_else},
                 DCTERMS.title: {rdf.literal('cccc')},
-                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_bc},
+                DCTERMS.subject: {BLARG.subj_ac, BLARG.subj_bc, BLARG.subj_c},
                 DCTERMS.description: {rdf.literal('The danger is unleashed only if you substantially disturb this place physically. This place is best shunned and left uninhabited.', language='en')},
             },
             BLARG.someone_else: {
@@ -232,7 +327,13 @@ class CommonTrovesearchTests(RealElasticTestCase):
                 },
             },
         })
-        self._index_indexcards([_card_a, _card_b, _card_c])
+        _cards = {
+            BLARG.a: _card_a,
+            BLARG.b: _card_b,
+            BLARG.c: _card_c,
+        }
+        self._index_indexcards(_cards.values())
+        return _cards
 
     def cardsearch_cases(self) -> Iterator[tuple[dict[str, str], set[str] | list[str]]]:
         # using data from _fill_test_data_for_querying
@@ -421,7 +522,7 @@ class CommonTrovesearchTests(RealElasticTestCase):
             [BLARG.c, BLARG.a, BLARG.b],  # ordered list
         )
 
-    def valuesearch_simple_cases(self) -> Iterator[tuple[dict[str, str], set[str]]]:
+    def valuesearch_cases(self) -> Iterator[tuple[dict[str, str], set[str]]]:
         yield (
             {'valueSearchPropertyPath': 'references'},
             {BLARG.b, BLARG.c},
@@ -430,9 +531,22 @@ class CommonTrovesearchTests(RealElasticTestCase):
             {'valueSearchPropertyPath': 'dateCreated'},
             {'1999', '2012', '2024'},
         )
-        # TODO: more
-
-    def valuesearch_complex_cases(self) -> Iterator[tuple[dict[str, str], set[str]]]:
+        yield (
+            {'valueSearchPropertyPath': 'subject'},
+            {BLARG.subj_a, BLARG.subj_ac, BLARG.subj_b, BLARG.subj_bc, BLARG.subj_c},
+        )
+        yield (
+            {'valueSearchPropertyPath': 'subject', 'cardSearchFilter[creator]': BLARG.someone},
+            {BLARG.subj_ac, BLARG.subj_bc, BLARG.subj_a, BLARG.subj_b},
+        )
+        yield (
+            {'valueSearchPropertyPath': 'subject', 'cardSearchFilter[creator]': BLARG.someone_else},
+            {BLARG.subj_ac, BLARG.subj_bc, BLARG.subj_c},
+        )
+        yield (
+            {'valueSearchPropertyPath': 'subject', 'cardSearchText': 'aaaa'},
+            {BLARG.subj_ac, BLARG.subj_a},
+        )
         yield (
             {
                 'valueSearchPropertyPath': 'references',
@@ -460,28 +574,39 @@ class CommonTrovesearchTests(RealElasticTestCase):
         ))
         self.current_index.pls_refresh()
 
+    def _delete_indexcards(self, indexcards: Iterable[trove_db.Indexcard]):
+        for _indexcard in indexcards:
+            _indexcard.pls_delete(notify_indexes=False)  # notify by hand to know when done
+        self._index_indexcards(indexcards)
+
     def _create_indexcard(self, focus_iri: str, rdf_tripledict: rdf.RdfTripleDictionary) -> trove_db.Indexcard:
         _suid = factories.SourceUniqueIdentifierFactory()
-        _raw = factories.RawDatumFactory(
-            suid=_suid,
-        )
-        _indexcard = trove_db.Indexcard.objects.create(
-            source_record_suid=_suid,
-        )
+        _indexcard = trove_db.Indexcard.objects.create(source_record_suid=_suid)
+        self._update_indexcard_content(_indexcard, focus_iri, rdf_tripledict)
         # an osfmap_json card is required for indexing, but not used in these tests
-        trove_db.DerivedIndexcard.objects.create(
+        trove_db.DerivedIndexcard.objects.get_or_create(
             upriver_indexcard=_indexcard,
             deriver_identifier=trove_db.ResourceIdentifier.objects.get_or_create_for_iri(TROVE['derive/osfmap_json']),
         )
-        trove_db.LatestIndexcardRdf.objects.create(
-            from_raw_datum=_raw,
-            indexcard=_indexcard,
-            focus_iri=focus_iri,
-            rdf_as_turtle=rdf.turtle_from_tripledict(rdf_tripledict),
-            turtle_checksum_iri='foo',  # not enforced
-        )
-        self._indexcard_focus_by_uuid[str(_indexcard.uuid)] = focus_iri
         return _indexcard
+
+    def _update_indexcard_content(
+        self,
+        indexcard: trove_db.Indexcard,
+        focus_iri: str,
+        rdf_tripledict: rdf.RdfTripleDictionary,
+    ) -> None:
+        _raw = factories.RawDatumFactory(suid=indexcard.source_record_suid)
+        trove_db.LatestIndexcardRdf.objects.update_or_create(
+            indexcard=indexcard,
+            defaults={
+                'from_raw_datum': _raw,
+                'focus_iri': focus_iri,
+                'rdf_as_turtle': rdf.turtle_from_tripledict(rdf_tripledict),
+                'turtle_checksum_iri': 'foo',  # not enforced
+            },
+        )
+        self._indexcard_focus_by_uuid[str(indexcard.uuid)] = focus_iri
 
     def _create_supplement(
         self,

--- a/trove/models/indexcard.py
+++ b/trove/models/indexcard.py
@@ -205,7 +205,7 @@ class Indexcard(models.Model):
     def get_iri(self):
         return trove_indexcard_iri(self.uuid)
 
-    def pls_delete(self):
+    def pls_delete(self, *, notify_indexes=True):
         # do not actually delete Indexcard, just mark deleted:
         if self.deleted is None:
             self.deleted = timezone.now()
@@ -220,9 +220,10 @@ class Indexcard(models.Model):
             .filter(upriver_indexcard=self)
             .delete()
         )
-        # TODO: rearrange to avoid local import
-        from share.search.index_messenger import IndexMessenger
-        IndexMessenger().notify_indexcard_update([self])
+        if notify_indexes:
+            # TODO: rearrange to avoid local import
+            from share.search.index_messenger import IndexMessenger
+            IndexMessenger().notify_indexcard_update([self])
 
     def __repr__(self):
         return f'<{self.__class__.__qualname__}({self.uuid}, {self.source_record_suid})'

--- a/trove/trovesearch/search_params.py
+++ b/trove/trovesearch/search_params.py
@@ -468,10 +468,9 @@ class CardsearchParams(BaseTroveParams):
     cardsearch_textsegment_set: frozenset[Textsegment]
     cardsearch_filter_set: frozenset[SearchFilter]
     index_strategy_name: str | None
-    sort_list: tuple[SortParam]
+    sort_list: tuple[SortParam, ...]
     page_cursor: PageCursor
     related_property_paths: tuple[Propertypath, ...]
-    unnamed_iri_values: frozenset[str]
 
     @classmethod
     def parse_queryparams(cls, queryparams: QueryparamDict) -> dict:
@@ -485,7 +484,6 @@ class CardsearchParams(BaseTroveParams):
             'page_cursor': _get_page_cursor(queryparams),
             'include': None,  # TODO
             'related_property_paths': _get_related_property_paths(_filter_set),
-            'unnamed_iri_values': frozenset(),  # TODO: frozenset(_get_unnamed_iri_values(_filter_set)),
         }
 
     def to_querydict(self) -> QueryDict:


### PR DESCRIPTION
follow-up to #828 

- fix `trovesearch_denorm` error loading related property counts (with tests)
- improve `trovesearch_denorm`'s handling of removed values:
  - add `chunk_timestamp` field
  - instead of deleting all value-docs before each chunk, use `chunk_timestamp` to delete only the value-docs not 
updated _after_ each chunk
  - add tests for de-indexing cards and values
- remove some dead code