### PR TITLE
[ENG-6576] drop trailing slashes for value-search

### DIFF
--- a/tests/share/search/index_strategy/test_trove_indexcard_flats.py
+++ b/tests/share/search/index_strategy/test_trove_indexcard_flats.py
@@ -10,3 +10,12 @@ class TestTroveIndexcardFlats(_common_trovesearch_tests.CommonTrovesearchTests):
 
     def cardsearch_integer_cases(self):
         yield from ()  # integers not indexed by this strategy
+
+    def cardsearch_trailingslash_cases(self):
+        yield from ()  # trailing-slash handling improved in trovesearch_denorm
+
+    def valuesearch_sameas_cases(self):
+        yield from ()  # sameas handling improved in trovesearch_denorm
+
+    def valuesearch_trailingslash_cases(self):
+        yield from ()  # trailing-slash handling improved in trovesearch_denorm


### PR DESCRIPTION
- when indexing iri values for value-search aggregations, drop trailing slash and ensure a single iri (not including synonyms)
- update `trovesearch_denorm` mappings: single iri for each value, better synonym handling
- update tests with fixes while leaving old _flats strategy as-is (because it'll be removed before long...)