### PR TITLE
fix: retain entire iris in dynamic field names

### DIFF
--- a/share/search/index_strategy/_trovesearch_util.py
+++ b/share/search/index_strategy/_trovesearch_util.py
@@ -107,10 +107,7 @@ def iris_synonyms(iris: typing.Iterable[str], rdfdoc: rdf.RdfGraph) -> set[str]:
 
 def propertypath_as_keyword(path: Propertypath) -> str:
     assert not is_globpath(path)
-    return json.dumps([
-        get_sufficiently_unique_iri(_iri)
-        for _iri in path
-    ])
+    return json.dumps(path)
 
 
 def b64(value: str) -> str:


### PR DESCRIPTION
fix(trovesearch_denorm): whole-iris field names

retain the entire iri for path-based field names --
this makes them easily reversible for highlighting fields that match

(previously used "sufficiently unique" iris like "://foo.example/blarg",
which works well enough, except it'd take knowledge to get the original -- see e.g. `://purl.org/dc/terms/description` in search results' "Context" at https://staging.osf.io/search?q=miscellaneous )

(bug introduced in 7b68b96529864e94003519841aa15faac385b2e0 )
