### PR TITLE
[ENG-6654] fixfix: correct misunderstanding, handle conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,9 @@ services:
 
   worker:
     image: quay.io/centerforopenscience/share:develop
-    command: /usr/local/bin/celery --app project worker --uid daemon -l INFO
+    command:
+      chown -R daemon:daemon /elastic8_certs/ &&
+      /usr/local/bin/celery --app project worker --uid daemon -l INFO
     depends_on:
       - postgres
       - rabbitmq

--- a/project/settings.py
+++ b/project/settings.py
@@ -314,6 +314,7 @@ ELASTICSEARCH = {
     'TIMEOUT': int(os.environ.get('ELASTICSEARCH_TIMEOUT', '45')),
     'CHUNK_SIZE': int(os.environ.get('ELASTICSEARCH_CHUNK_SIZE', 2000)),
     'MAX_RETRIES': int(os.environ.get('ELASTICSEARCH_MAX_RETRIES', 7)),
+    'POST_INDEX_DELAY': int(os.environ.get('ELASTICSEARCH_POST_INDEX_DELAY', 3)),
 }
 ELASTICSEARCH5_URL = (
     os.environ.get('ELASTICSEARCH5_URL')

--- a/share/search/daemon.py
+++ b/share/search/daemon.py
@@ -79,7 +79,7 @@ class IndexerDaemonControl:
 
 
 class KombuMessageConsumer(ConsumerMixin):
-    PREFETCH_COUNT = 7500
+    PREFETCH_COUNT = settings.ELASTICSEARCH['CHUNK_SIZE']
 
     should_stop: bool  # (from ConsumerMixin)
 
@@ -129,7 +129,7 @@ class KombuMessageConsumer(ConsumerMixin):
 
 
 class IndexerDaemon:
-    MAX_LOCAL_QUEUE_SIZE = 5000
+    MAX_LOCAL_QUEUE_SIZE = settings.ELASTICSEARCH['CHUNK_SIZE']
 
     def __init__(self, index_strategy, *, stop_event=None, daemonthread_context=None):
         self.stop_event = (

--- a/share/search/index_strategy/elastic8.py
+++ b/share/search/index_strategy/elastic8.py
@@ -171,6 +171,13 @@ class Elastic8IndexStrategy(IndexStrategy):
                     status_code=_status,
                     error_text=str(_response_body),
                 )
+        for _message_id in _action_tracker.remaining_done_messages():
+            yield messages.IndexMessageResponse(
+                is_done=True,
+                index_message=messages.IndexMessage(messages_chunk.message_type, _message_id),
+                status_code=HTTPStatus.OK.value,
+                error_text=None,
+            )
         self.after_chunk(messages_chunk, _indexnames)
 
     # abstract method from IndexStrategy

--- a/share/search/index_strategy/trovesearch_denorm.py
+++ b/share/search/index_strategy/trovesearch_denorm.py
@@ -162,7 +162,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
                 'card_pks': messages_chunk.target_ids_chunk,
                 'timestamp': messages_chunk.timestamp,
             },
-            countdown=3,  # TODO: config?
+            countdown=settings.ELASTICSEARCH['POST_INDEX_DELAY'],
         )
 
     # abstract method from Elastic8IndexStrategy

--- a/share/search/index_strategy/trovesearch_denorm.py
+++ b/share/search/index_strategy/trovesearch_denorm.py
@@ -11,6 +11,7 @@ from typing import (
     Literal,
 )
 
+import celery
 from django.conf import settings
 import elasticsearch8
 from primitive_metadata import primitive_rdf as rdf
@@ -154,15 +155,14 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
 
     # override method from Elastic8IndexStrategy
     def after_chunk(self, messages_chunk: messages.MessagesChunk, indexnames: Iterable[str]):
-        # refresh to avoid delete-by-query conflicts
-        self.es8_client.indices.refresh(index=','.join(indexnames))
-        # delete any docs that belong to cards in this chunk but weren't touched by indexing
-        self.es8_client.delete_by_query(
-            index=list(indexnames),
-            query={'bool': {'must': [
-                {'terms': {'card.card_pk': messages_chunk.target_ids_chunk}},
-                {'range': {'chunk_timestamp': {'lt': messages_chunk.timestamp}}},
-            ]}},
+        task__delete_iri_value_scraps.apply_async(
+            kwargs={
+                'index_strategy_name': self.name,
+                'indexnames': list(indexnames),
+                'card_pks': messages_chunk.target_ids_chunk,
+                'timestamp': messages_chunk.timestamp,
+            },
+            countdown=3,  # TODO: config?
         )
 
     # abstract method from Elastic8IndexStrategy
@@ -888,3 +888,46 @@ def _any_query(queries: abc.Collection[dict]):
         (_query,) = queries
         return _query
     return {'bool': {'should': list(queries), 'minimum_should_match': 1}}
+
+
+@celery.shared_task(
+    name='share.search.index_strategy.trovesearch_denorm.task__delete_iri_value_scraps',
+    max_retries=None,  # retries only on delete_by_query conflicts -- should work eventually!
+    retry_backoff=True,
+    bind=True,  # for explicit retry
+)
+def task__delete_iri_value_scraps(
+    task: celery.Task,
+    index_strategy_name: str,
+    card_pks: list[int],
+    indexnames: list[str],
+    timestamp: int,
+):
+    '''followup task to delete value-docs no longer present
+
+    each time an index-card is updated, value-docs are created (or updated) for each iri value
+    present in the card's contents -- if some values are absent from a later update, the
+    corresponding docs will remain untouched
+
+    this task deletes those untouched value-docs after the index has refreshed at its own pace
+    (allowing a slightly longer delay for items to _stop_ matching queries for removed values)
+    '''
+    from share.search.index_strategy import get_index_strategy
+    _index_strategy = get_index_strategy(index_strategy_name)
+    assert isinstance(_index_strategy, Elastic8IndexStrategy)
+    # delete any docs that belong to cards in this chunk but weren't touched by indexing
+    _delete_resp = _index_strategy.es8_client.delete_by_query(
+        index=indexnames,
+        query={'bool': {'must': [
+            {'terms': {'card.card_pk': card_pks}},
+            {'range': {'chunk_timestamp': {'lt': timestamp}}},
+        ]}},
+        params={
+            'slices': 'auto',
+            'conflicts': 'proceed',  # count conflicts instead of halting
+            'request_cache': False,
+        },
+    )
+    _conflict_count = _delete_resp.get('version_conflicts', 0)
+    if _conflict_count > 0:
+        raise task.retry()

--- a/share/search/messages.py
+++ b/share/search/messages.py
@@ -144,12 +144,7 @@ class DaemonMessage(abc.ABC):
     def ack(self):
         if self.kombu_message is None:
             raise exceptions.DaemonMessageError('ack! called DaemonMessage.ack() but there is nothing to ack')
-        try:
-            self.kombu_message.ack()
-        except (ConnectionError, amqp.exceptions.ConnectionError):
-            # acks must be on the same channel the message was received on --
-            # if the channel failed, oh well, the message already got requeued
-            pass
+        self.kombu_message.ack()
 
     def requeue(self):
         if self.kombu_message is None:

--- a/share/search/messages.py
+++ b/share/search/messages.py
@@ -6,8 +6,6 @@ import logging
 import time
 import typing
 
-import amqp.exceptions
-
 from share.search import exceptions
 from share.util import chunked
 

--- a/tests/share/search/index_strategy/_with_real_services.py
+++ b/tests/share/search/index_strategy/_with_real_services.py
@@ -24,6 +24,16 @@ class RealElasticTestCase(TransactionTestCase):
         super().setUp()
         self.enterContext(mock.patch('share.models.core._setup_user_token_and_groups'))
         self.index_strategy = self.get_index_strategy()
+
+        def _fake_get_index_strategy(name):
+            if self.index_strategy.name == name:
+                return self.index_strategy
+            raise ValueError(f'unknown index strategy in test: {name}')
+
+        self.enterContext(mock.patch(
+            'share.search.index_strategy.get_index_strategy',
+            new=_fake_get_index_strategy,
+        ))
         self.index_messenger = IndexMessenger(
             celery_app=celery_app,
             index_strategys=[self.index_strategy],

--- a/tests/share/search/index_strategy/test_trovesearch_denorm.py
+++ b/tests/share/search/index_strategy/test_trovesearch_denorm.py
@@ -1,9 +1,29 @@
-from share.search.index_strategy.trovesearch_denorm import TrovesearchDenormIndexStrategy
+from unittest import mock
+
+from share.search.index_strategy.trovesearch_denorm import (
+    TrovesearchDenormIndexStrategy,
+    task__delete_iri_value_scraps,
+)
 
 from . import _common_trovesearch_tests
 
 
-class TestTroveIndexcardFlats(_common_trovesearch_tests.CommonTrovesearchTests):
+class TestTrovesearchDenorm(_common_trovesearch_tests.CommonTrovesearchTests):
+    def setUp(self):
+        super().setUp()
+
+        # make the followup delete task eager
+        def _fake_apply_async(*args, **kwargs):
+            kwargs['countdown'] = 0  # don't wait
+            task__delete_iri_value_scraps.apply(*args, **kwargs)
+        self.enterContext(
+            mock.patch.object(
+                task__delete_iri_value_scraps,
+                'apply_async',
+                new=_fake_apply_async,
+            )
+        )
+
     # for RealElasticTestCase
     def get_index_strategy(self):
         return TrovesearchDenormIndexStrategy('test_trovesearch_denorm')


### PR DESCRIPTION
- partly revert #835 (remove `ensure_ack`, `ack_callback`) -- messages can _only_ be ack'd thru the channel they were received by, so trying to recover a channel to ack thru does nothing
- handle easily-detectable delete_by_query conflicts in a followup celery task (so the indexer doesn't fall over on it)
- local setup: allow the worker's `daemon` user to access elastic8
- update consumer prefetch limit to match the indexing chunk size (seems to avoid connection errors, [maybe this is why](https://stackoverflow.com/a/36114095))
- try avoiding connection errors when calling `message.ack()` -- do a bit more book-keeping to know when a bulk elastic action is the last for its index-card, so it can ack immediately then instead of waiting 'til the whole chunk has completed
- test updates to handle changes...