### PR TITLE
[ENG-5907] osfmap: suggest `affiliation` for preprints

### DIFF
--- a/share/models/feature_flag.py
+++ b/share/models/feature_flag.py
@@ -32,6 +32,7 @@ class FeatureFlag(models.Model):
     SUGGEST_CREATOR_FACET = 'suggest_creator_facet'
     FORBID_UNTRUSTED_FEED = 'forbid_untrusted_feed'
     TROVESEARCH_DENORMILY = 'trovesearch_denormily'
+    PREPRINT_AFFILIATIONS = 'preprint_affiliations'
 
     # name _should_ be one of the constants above, but that is not enforced by `choices`
     name = models.TextField(unique=True)

--- a/trove/vocab/osfmap.py
+++ b/trove/vocab/osfmap.py
@@ -851,7 +851,7 @@ PREPRINT_SUGGESTED_PROPERTY_PATHS = (
     (DCTERMS.subject,),
     (DCTERMS.rights,),
     (DCTERMS.publisher,),
-    (DCTERMS.creator, OSFMAP.affiliation),
+    (OSFMAP.affiliation,),
     (OSFMAP.hasDataResource,),
     (OSFMAP.hasPreregisteredAnalysisPlan,),
     (OSFMAP.hasPreregisteredStudyDesign,),
@@ -906,6 +906,14 @@ def suggested_property_paths(type_iris: set[str]) -> tuple[tuple[str, ...], ...]
         _suggested = AGENT_SUGGESTED_PROPERTY_PATHS
     elif type_iris == {OSFMAP.Preprint}:
         _suggested = PREPRINT_SUGGESTED_PROPERTY_PATHS
+        if not FeatureFlag.objects.flag_is_up(FeatureFlag.PREPRINT_AFFILIATIONS):
+            # replace `affilation` with `creator.affiliation`
+            _no = (OSFMAP.affiliation,)
+            _instead = (DCTERMS.creator, OSFMAP.affiliation)
+            _suggested = tuple(
+                (_instead if (_path == _no) else _path)
+                for _path in _suggested
+            )
     elif type_iris == {OSFMAP.File}:
         _suggested = FILE_SUGGESTED_PROPERTY_PATHS
     elif type_iris <= {OSFMAP.Project, OSFMAP.ProjectComponent}:


### PR DESCRIPTION
when feature flag PREPRINT_AFFILIATIONS is up, suggest `affiliation` instead of `creator.affiliation` for searching preprints