### PR TITLE
[ENG-6708][ENG-7286] improved trovesearch_denorm...

### DIFF
--- a/share/search/index_strategy/_base.py
+++ b/share/search/index_strategy/_base.py
@@ -121,7 +121,7 @@ If you made these changes on purpose, pls update {self.__class__.__qualname__} w
         _strategy = self.with_strategy_check(_strategy_check)
         return _strategy.get_index(_etc[0] if _etc else '')
 
-    def with_strategy_check(self, strategy_check: str) -> IndexStrategy:
+    def with_strategy_check(self, strategy_check: str) -> typing.Self:
         return dataclasses.replace(self, strategy_check=strategy_check)
 
     def pls_setup(self, *, skip_backfill=False) -> None:

--- a/share/search/index_strategy/_trovesearch_util.py
+++ b/share/search/index_strategy/_trovesearch_util.py
@@ -45,13 +45,7 @@ TEXT_MAPPING = {
     'type': 'text',
     'index_options': 'offsets',  # for highlighting
 }
-IRI_KEYWORD_MAPPING = {
-    'type': 'object',
-    'properties': {  # for indexing iri values two ways:
-        'exact': KEYWORD_MAPPING,  # the exact iri value (e.g. "https://foo.example/bar/")
-        'suffuniq': KEYWORD_MAPPING,  # "sufficiently unique" (e.g. "://foo.example/bar")
-    },
-}
+TEXT_PATH_DEPTH_MAX = 1
 
 
 ###

--- a/share/search/index_strategy/trovesearch_denorm.py
+++ b/share/search/index_strategy/trovesearch_denorm.py
@@ -451,7 +451,9 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
         def _texts_by_depth(self, walk: ts.GraphWalk):
             _by_depth: dict[int, set[str]] = defaultdict(set)
             for _path, _text_set in walk.text_values.items():
-                _by_depth[len(_path)].update(_text.unicode_value for _text in _text_set)
+                _depth = len(_path)
+                if _depth <= ts.TEXT_PATH_DEPTH_MAX:
+                    _by_depth[_depth].update(_text.unicode_value for _text in _text_set)
             return {
                 _depth_field_name(_depth): list(_value_set)
                 for _depth, _value_set in _by_depth.items()

--- a/share/search/index_strategy/trovesearch_denorm.py
+++ b/share/search/index_strategy/trovesearch_denorm.py
@@ -70,7 +70,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
     CURRENT_STRATEGY_CHECKSUM = ChecksumIri(
         checksumalgorithm_name='sha-256',
         salt='TrovesearchDenormIndexStrategy',
-        hexdigest='4c8784ddd08914ec779b33b8f1945b0b2ff026eea355392ab3c4fe2fe10d71fe',
+        hexdigest='ef44d5bc272589754b3b0753e5ee61719349fd96284b62ecafab1d0cb043bde9',
     )
 
     # abstract method from Elastic8IndexStrategy
@@ -111,7 +111,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
     def _index_settings(cls):
         return {
             'number_of_shards': 5,
-            'number_of_replicas': 2,
+            'number_of_replicas': 1,
         }
 
     @classmethod

--- a/tests/trove/_input_output_tests.py
+++ b/tests/trove/_input_output_tests.py
@@ -43,6 +43,12 @@ class BasicInputOutputTestCase(TestCase):
             pprint.pformat(_actual_output),
         )))
 
+    def enterContext(self, context_manager):
+        # TestCase.enterContext added in python3.11 -- implementing here until then
+        result = context_manager.__enter__()
+        self.addCleanup(lambda: context_manager.__exit__(None, None, None))
+        return result
+
     ###
     # private details
 

--- a/tests/trove/render/test_jsonapi_renderer.py
+++ b/tests/trove/render/test_jsonapi_renderer.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 from trove.render.jsonapi import RdfJsonapiRenderer
 from trove.render._rendering import SimpleRendering
@@ -12,6 +13,12 @@ def _jsonapi_item_sortkey(jsonapi_item: dict):
 
 class _BaseJsonapiRendererTest(_base.TroveJsonRendererTests):
     renderer_class = RdfJsonapiRenderer
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(
+            mock.patch('trove.render.jsonapi.time.time_ns', return_value=112358)
+        )
 
     def _get_rendered_output(self, rendering):
         _json = super()._get_rendered_output(rendering)
@@ -28,7 +35,7 @@ class TestJsonapiRenderer(_BaseJsonapiRendererTest):
             mediatype='application/vnd.api+json',
             rendered_content=json.dumps({
                 "data": {
-                    "id": "68808d2c76cd5f7ff4e0f470592da8f02be1f615b05a143cc3821c5288e13f11",
+                    "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYUNhcmQ=",
                     "type": "index-card",
                     "attributes": {
                         "resourceIdentifier": [
@@ -60,7 +67,7 @@ class TestJsonapiRenderer(_BaseJsonapiRendererTest):
             mediatype='application/vnd.api+json',
             rendered_content=json.dumps({
                 "data": {
-                    "id": "11f60e4d2fceb50ca695c3c77dcd7983ff78116ff2e7a2f315800c8ca645f469",
+                    "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYVN1YmplY3Q=",
                     "type": BLARG.aType,
                     "meta": {
                         BLARG.hasIri: [BLARG.anIri],
@@ -83,7 +90,7 @@ class TestJsonapiSearchRenderer(_BaseJsonapiRendererTest, _base.TrovesearchJsonR
             mediatype='application/vnd.api+json',
             rendered_content=json.dumps({
                 "data": {
-                    "id": "4b79207d8ecd4817c36b75b16cee6c4a1874774cfbcfbd0caede339148403325",
+                    "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYVNlYXJjaA==",
                     "type": "index-card-search",
                     "attributes": {
                         "totalResultCount": 0,
@@ -98,7 +105,7 @@ class TestJsonapiSearchRenderer(_BaseJsonapiRendererTest, _base.TrovesearchJsonR
             mediatype='application/vnd.api+json',
             rendered_content=json.dumps({
                 "data": {
-                    "id": "79183793c0eea20ca6338d71c936deee113b94641ee77346fb66f9c4bcebfe0a",
+                    "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYVNlYXJjaEZldw==",
                     "type": "index-card-search",
                     "attributes": {
                         "totalResultCount": 3
@@ -107,15 +114,15 @@ class TestJsonapiSearchRenderer(_BaseJsonapiRendererTest, _base.TrovesearchJsonR
                         "searchResultPage": {
                             "data": [
                                 {
-                                    "id": "dc0604c7e9c07576b57646119784de65e7204fc7c860cc1b9be8ebec5f2b96ba",
+                                    "id": "112358-0",
                                     "type": "search-result"
                                 },
                                 {
-                                    "id": "367b30e8a0eece555ac15fda82bb28f535f1f8beb97397c01162d619cd7058bc",
+                                    "id": "112358-1",
                                     "type": "search-result"
                                 },
                                 {
-                                    "id": "26afa96fdbd189e4c4aeac921a42e9d3f09eb94b59ffd4b9ad300c524536cc97",
+                                    "id": "112358-2",
                                     "type": "search-result"
                                 }
                             ]
@@ -127,43 +134,43 @@ class TestJsonapiSearchRenderer(_BaseJsonapiRendererTest, _base.TrovesearchJsonR
                 },
                 "included": [
                     {
-                        "id": "dc0604c7e9c07576b57646119784de65e7204fc7c860cc1b9be8ebec5f2b96ba",
+                        "id": "112358-0",
                         "type": "search-result",
                         "relationships": {
                             "indexCard": {
                                 "data": {
-                                    "id": "68808d2c76cd5f7ff4e0f470592da8f02be1f615b05a143cc3821c5288e13f11",
+                                    "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYUNhcmQ=",
                                     "type": "index-card"
                                 }
                             }
                         }
                     },
                     {
-                        "id": "26afa96fdbd189e4c4aeac921a42e9d3f09eb94b59ffd4b9ad300c524536cc97",
+                        "id": "112358-1",
                         "type": "search-result",
                         "relationships": {
                             "indexCard": {
                                 "data": {
-                                    "id": "db657130943f3c9f4cc527b23a6a246b095f62673f2cc7fc906d5914678bd337",
+                                    "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYUNhcmRk",
                                     "type": "index-card"
                                 }
                             }
                         }
                     },
                     {
-                        "id": "367b30e8a0eece555ac15fda82bb28f535f1f8beb97397c01162d619cd7058bc",
+                        "id": "112358-2",
                         "type": "search-result",
                         "relationships": {
                             "indexCard": {
                                 "data": {
-                                    "id": "4e6134629cc3117a123cee8a8dc633a46401c9725f01d63f689d7b84f2422359",
+                                    "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYUNhcmRkZA==",
                                     "type": "index-card"
                                 }
                             }
                         }
                     },
                     {
-                        "id": "68808d2c76cd5f7ff4e0f470592da8f02be1f615b05a143cc3821c5288e13f11",
+                        "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYUNhcmQ=",
                         "type": "index-card",
                         "meta": {
                             "foaf:primaryTopic": [
@@ -190,7 +197,7 @@ class TestJsonapiSearchRenderer(_BaseJsonapiRendererTest, _base.TrovesearchJsonR
                         }
                     },
                     {
-                        "id": "db657130943f3c9f4cc527b23a6a246b095f62673f2cc7fc906d5914678bd337",
+                        "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYUNhcmRkZA==",
                         "type": "index-card",
                         "meta": {
                             "foaf:primaryTopic": [
@@ -217,7 +224,7 @@ class TestJsonapiSearchRenderer(_BaseJsonapiRendererTest, _base.TrovesearchJsonR
                         }
                     },
                     {
-                        "id": "4e6134629cc3117a123cee8a8dc633a46401c9725f01d63f689d7b84f2422359",
+                        "id": "aHR0cDovL2JsYXJnLmV4YW1wbGUvdm9jYWIvYUNhcmRk",
                         "type": "index-card",
                         "meta": {
                             "foaf:primaryTopic": [

--- a/trove/trovesearch/search_params.py
+++ b/trove/trovesearch/search_params.py
@@ -240,6 +240,13 @@ class Textsegment:
             if param_name.bracketed_names
             else None
         )
+        if _propertypath_set:
+            if any((is_globpath(_path) and len(_path) > 1) for _path in _propertypath_set):
+                raise trove_exceptions.InvalidQueryParamName(
+                    str(param_name),
+                    'may not use glob-paths longer than "*" with search-text parameters',
+                )
+
         for _textsegment in cls.iter_from_text(param_value):
             if _propertypath_set:
                 yield dataclasses.replace(_textsegment, propertypath_set=_propertypath_set)

--- a/trove/trovesearch/trovesearch_gathering.py
+++ b/trove/trovesearch/trovesearch_gathering.py
@@ -389,7 +389,7 @@ def _load_cards_and_derived_contents(card_iris, value_iris, deriver_iri: str) ->
                 .queryset_for_iri(deriver_iri)
             ),
         )
-        .select_related('upriver_indexcard')
+        .select_related('upriver_indexcard', 'deriver_identifier')
         .prefetch_related('upriver_indexcard__focus_identifier_set')
     )
     if card_iris is not None:


### PR DESCRIPTION
improvements to `trovesearch_denorm` index strategy:
- skip indexing nested "identifier" text (saves 107 fields)
- allow wild-card properties only to depth 1 (disallow `cardSearchText[*.*]`)
- reduce `number_of_replicas` from 2 to 1
- fix: backfilling a new index shouldn't clear earlier indexes

other:
- use `select_related` to avoid n+1 queries on n search results
- stop hashing so much rendering valuesearch responses (get unique ids other ways)