### PR TITLE
[ENG-8050] fix: unprefix suggestedFilterOperator

### DIFF
--- a/trove/vocab/osfmap.py
+++ b/trove/vocab/osfmap.py
@@ -821,6 +821,26 @@ OSFMAP_THESAURUS: RdfTripleDictionary = {
             literal('no-conflict-of-interest', language='en'),
         },
     },
+    # filter-operator values from `trove.vocab.trove.TROVE_API_THESAURUS`
+    # duplicated here so `osfmap_json_shorthand` does not prefix "trove:"
+    TROVE['any-of']: {
+        JSONAPI_MEMBERNAME: {literal('any-of', language='en')},
+    },
+    TROVE['none-of']: {
+        JSONAPI_MEMBERNAME: {literal('none-of', language='en')},
+    },
+    TROVE['is-absent']: {
+        JSONAPI_MEMBERNAME: {literal('is-absent', language='en')},
+    },
+    TROVE['is-present']: {
+        JSONAPI_MEMBERNAME: {literal('is-present', language='en')},
+    },
+    TROVE.before: {
+        JSONAPI_MEMBERNAME: {literal('before', language='en')},
+    },
+    TROVE.after: {
+        JSONAPI_MEMBERNAME: {literal('after', language='en')},
+    },
 }
 
 


### PR DESCRIPTION
`suggestedFilterOperator` should be json-serialized without a prefix (e.g. "is-present", "any-of", "at-date") but are now prefixed with trove: ("trove:is-present", "trove:any-of", "trove:at-date"), which breaks parts of osf frontend search

this fix adds filter-operators to `trove.vocab.osfmap.OSFMAP_THESAURUS` so `osfmap_json_shorthand()` correctly abbreviates them without prefix (...more robust/consistent namespace handling is beyond scope...)

see [example json](https://staging-share.osf.io/trove/index-card-search?cardSearchFilter%5BresourceType%5D=Registration&include=trove%3ArelatedPropertyList&acceptMediatype=application%2Fvnd.api%2Bjson) (search "suggestedFilterOperator" -- values should not begin with "trove:")

[ENG-8050]

[ENG-8050]: https://openscience.atlassian.net/browse/ENG-8050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ