### PR TITLE
[ENG-8287] Fix/osfmap mismatches

### DIFF
--- a/tests/trove/derive/test_osfmap_json_mini.py
+++ b/tests/trove/derive/test_osfmap_json_mini.py
@@ -154,6 +154,12 @@ class TestOsfmapJsonMiniDeriver(BaseIndexcardDeriverTest):
         },
         'osfmap-registration': {
             "@id": "https://osf.example/2c4st",
+            "accessService": [{
+                "@id": "https://osf.example",
+                "identifier": [{"@value": "https://osf.example"}],
+                "name": [{"@value": "OSF"}],
+                "resourceType": [{"@id": "Agent"}, {"@id": "Organization"}],
+            }],
             "resourceType": [
                 {"@id": "Registration"}
             ],
@@ -455,6 +461,10 @@ class TestOsfmapJsonMiniDeriver(BaseIndexcardDeriverTest):
                     ]
                 }
             ],
+            "qualifiedAttribution": [{
+                "agent": [{"@id": "https://osf.example/bhcjn"}],
+                "hadRole": [{"@id": "osf:admin-contributor"}],
+            }],
             "archivedAt": [
                 {"@id": "https://archive.example/details/osf-registrations-2c4st-v1"}
             ],

--- a/trove/derive/osfmap_json_mini.py
+++ b/trove/derive/osfmap_json_mini.py
@@ -2,36 +2,8 @@ from trove.vocab import namespaces as ns
 from trove.derive.osfmap_json import OsfmapJsonFullDeriver
 from trove.vocab.namespaces import TROVE
 
-INCLUDED_PREDICATE_SET = frozenset({
-    ns.RDF.type,
-    ns.DCTERMS.title,
-    ns.DCTERMS.creator,
-    ns.DCTERMS.date,
-    ns.DCTERMS.created,
-    ns.FOAF.name,
-    ns.OWL.sameAs,
-    ns.DCTERMS.conformsTo,
-    ns.DCTERMS.dateCopyrighted,
-    ns.DCTERMS.description,
-    ns.DCTERMS.hasPart,
-    ns.DCTERMS.isVersionOf,
-    ns.DCTERMS.modified,
-    ns.DCTERMS.publisher,
-    ns.DCTERMS.rights,
-    ns.DCTERMS.subject,
-    ns.DCTERMS.isPartOf,
-    ns.DCTERMS.identifier,
-    ns.SKOS.inScheme,
-    ns.SKOS.prefLabel,
-    ns.OSFMAP.affiliation,
-    ns.OSFMAP.archivedAt,
-    ns.DCTERMS.dateAccepted,
-    ns.DCTERMS.dateModified,
-    ns.OSFMAP.hostingInstitution,
-    ns.OSFMAP.keyword,
-    ns.OSFMAP.fileName,
-    ns.OSFMAP.filePath,
-    ns.OSFMAP.isContainedBy
+EXCLUDED_PREDICATE_SET = frozenset({
+    ns.OSFMAP.contains,
 })
 
 
@@ -57,4 +29,4 @@ class OsfmapJsonMiniDeriver(OsfmapJsonFullDeriver):
 
     @staticmethod
     def _should_keep_predicate(predicate: str) -> bool:
-        return predicate in INCLUDED_PREDICATE_SET
+        return predicate not in EXCLUDED_PREDICATE_SET

--- a/trove/vocab/osfmap.py
+++ b/trove/vocab/osfmap.py
@@ -572,10 +572,10 @@ OSFMAP_THESAURUS: RdfTripleDictionary = {
             literal('accessService', language='en'),
         },
     },
-    DCAT.accessUrl: {
+    DCAT.accessURL: {
         RDF.type: {RDF.Property},
         JSONAPI_MEMBERNAME: {
-            literal('accessUrl', language='en'),
+            literal('accessURL', language='en'),
         },
     },
     OSFMAP.hostingInstitution: {

--- a/trove/vocab/osfmap.py
+++ b/trove/vocab/osfmap.py
@@ -356,13 +356,13 @@ OSFMAP_THESAURUS: RdfTripleDictionary = {
             literal('isSupplementedBy', language='en'),
         },
     },
-    OSFMAP.verifiedLinks: {
+    OSFMAP.verifiedLink: {
         RDF.type: {RDF.Property},
         RDFS.label: {
             literal('Verified Links', language='en'),
         },
         JSONAPI_MEMBERNAME: {
-            literal('verifiedLinks', language='en'),
+            literal('verifiedLink', language='en'),
         },
     },
     OSFMAP.archivedAt: {


### PR DESCRIPTION
- correct `osf:verifiedLink` (previously `osf:verifiedLinks`)
- correct `dcat:accessURL` (previously `dcat:accessUrl`)
- in the "mini" osfmap json representation, use an "excluded" set instead of an "included" set, so newly added properties are included by default
- (incidental) allow `fields=...` api query parameter for TSV/CSV columns (same as `fields[*]=...`)

[ENG-8287]

[ENG-8287]: https://openscience.atlassian.net/browse/ENG-8287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ