### PR TITLE
[ENG-9918] fix: cap length for iri_values doc id

### DIFF
--- a/share/search/index_strategy/trovesearch_denorm.py
+++ b/share/search/index_strategy/trovesearch_denorm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from collections import abc, defaultdict
 import dataclasses
 import functools
+import hashlib
 import itertools
 import json
 import logging
@@ -374,7 +375,7 @@ class TrovesearchDenormIndexStrategy(Elastic8IndexStrategy):
             return (
                 _card_pk
                 if value_iri is None
-                else f'{_card_pk}-{ts.b64(value_iri)}'
+                else f'{_card_pk}-{hashlib.sha256(value_iri.encode()).hexdigest()}'
             )
 
         @functools.cached_property


### PR DESCRIPTION
elasticsearch document ids may only be 512 bytes long, but the id used for documents in `trovesearch_denorm`'s `iri_values` index uses a base64-encoded url that may be longer -- use a hash instead

note: this should be safe to change in-place, because old `iri_values` documents are deleted by `task__delete_iri_value_scraps` based on their `chunk_timestamp` -- this was intended for catching values removed from a later version of a metadata record, but in this case the same logic will also clean up `iri_values` documents using the older base64 id